### PR TITLE
fix(jsonjsdb-py): load_table fails on nullable columns with late nume…

### DIFF
--- a/jsonjsdb-py/CHANGELOG.md
+++ b/jsonjsdb-py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.6
+
+fix: `load_table()` fails with `ComputeError` when a nullable column is all `null` in the first inferred rows and contains a numeric value later
+
 ## 0.8.5
 
 fix: `add_all()` fails with `ComputeError` when leading rows have `None` and later rows have `str` values

--- a/jsonjsdb-py/pyproject.toml
+++ b/jsonjsdb-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jsonjsdb"
-version = "0.8.5"
+version = "0.8.6"
 description = "Python library for JSONJS database loading"
 authors = [{ name = "datannur" }]
 readme = "README.md"

--- a/jsonjsdb-py/src/jsonjsdb/loader.py
+++ b/jsonjsdb-py/src/jsonjsdb/loader.py
@@ -13,7 +13,7 @@ def load_table(path: Path) -> pl.DataFrame:
     - Converts 'id' column to string type
     - Converts '*_ids' columns from comma-separated strings to list[str]
     """
-    df = pl.read_json(path)
+    df = pl.read_json(path, infer_schema_length=None)
 
     if df.is_empty():
         return df

--- a/jsonjsdb-py/tests/test_jsonjsdb.py
+++ b/jsonjsdb-py/tests/test_jsonjsdb.py
@@ -1300,3 +1300,19 @@ def test_save_nan_as_null(tmp_path: Path):
 
     js_raw = (tmp_path / "data.json.js").read_text()
     assert "NaN" not in js_raw
+
+
+def test_load_nullable_column_with_late_value(tmp_path: Path):
+    """Should load table where a column is null in early rows and numeric later."""
+    table_index = [{"name": "variable", "last_modif": 0}]
+    (tmp_path / "__table__.json").write_text(json.dumps(table_index))
+
+    rows = [{"id": f"v{i}", "key": None} for i in range(120)]
+    rows[110]["key"] = 1
+    (tmp_path / "variable.json").write_text(json.dumps(rows))
+
+    db = Jsonjsdb(tmp_path)
+    all_rows = db["variable"].all()
+    assert len(all_rows) == 120
+    assert all_rows[110]["key"] == 1
+    assert all_rows[0]["key"] is None


### PR DESCRIPTION
…ric values

Use infer_schema_length=None in pl.read_json to scan all rows for type inference, fixing ComputeError when a column is null in early rows and contains a numeric value beyond the default inference window.