### PR TITLE
fix(jsonjsdb-builder): skip regeneration when file content is unchanged

### DIFF
--- a/jsonjsdb-builder/CHANGELOG.md
+++ b/jsonjsdb-builder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsonjsdb-builder
 
+## 0.6.11 (2026-04-07)
+
+- fix: skip table regeneration when source file mtime changes but content is identical (e.g. after git checkout)
+
 ## 0.6.10 (2026-04-04)
 
 - fix: prevent `__table__.json` rewrite on every dev server start

--- a/jsonjsdb-builder/package.json
+++ b/jsonjsdb-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonjsdb-builder",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Jsonjsdb database builder",
   "type": "module",
   "license": "MIT",

--- a/jsonjsdb-builder/src/JsonjsdbBuilder.ts
+++ b/jsonjsdb-builder/src/JsonjsdbBuilder.ts
@@ -12,6 +12,7 @@ import {
   readJsonjs,
   writeJsonjs,
   snakeToCamelKeys,
+  transformKeysToSnake,
   TableRow,
   Row,
 } from './TableSerializer'
@@ -254,14 +255,20 @@ export class JsonjsdbBuilder {
     outputMetadata: MetadataItem[],
   ): Promise<boolean> {
     const outputMetadataObj = this.metadataListToObject(outputMetadata)
+    this.newEvoEntries = []
     const updatePromises = []
     for (const row of inputMetadata) {
       const isInOutput = row.name in outputMetadataObj
       if (isInOutput && outputMetadataObj[row.name] >= row.lastModif) continue
       if (row.name === 'evolution') continue
-      updatePromises.push(this.updateTable(row.name))
+      updatePromises.push(
+        this.updateTable(row.name).then(changed => {
+          if (!changed && isInOutput) {
+            row.lastModif = outputMetadataObj[row.name]
+          }
+        }),
+      )
     }
-    this.newEvoEntries = []
     await Promise.all(updatePromises)
     return updatePromises.length > 0
   }
@@ -313,21 +320,24 @@ export class JsonjsdbBuilder {
     }
   }
 
-  private async updateTable(table: string): Promise<void> {
+  private async updateTable(table: string): Promise<boolean> {
     const inputFile = path.join(this.inputDb, `${table}.xlsx`)
+    const outputJsonFile = path.join(this.outputDb, `${table}.json`)
     const tableData = await readExcel(inputFile)
-    await this.addNewEvoEntries(table, tableData)
+    const newData = toObjects(transformKeysToSnake(tableData as Row[]))
+    const oldData = await readJsonjs(outputJsonFile)
+    if (JSON.stringify(newData) === JSON.stringify(oldData)) return false
+    await this.addNewEvoEntries(table, tableData, oldData)
     await writeJsonjs(this.outputDb, table, tableData, { toSnakeCase: true })
     console.log(`Jsonjsdb updating ${table}`)
+    return true
   }
 
   private async addNewEvoEntries(
     table: string,
     tableData: Row[],
+    oldTableData: TableRow[],
   ): Promise<void> {
-    const oldTableData = await readJsonjs(
-      path.join(this.outputDb, `${table}.json`),
-    )
     const newEvoEntries = compareDatasets(
       oldTableData,
       toObjects(tableData),

--- a/jsonjsdb-builder/src/TableSerializer.ts
+++ b/jsonjsdb-builder/src/TableSerializer.ts
@@ -8,7 +8,7 @@ function camelToSnake(str: string): string {
   return str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`)
 }
 
-function transformKeysToSnake(data: Row[]): Row[] {
+export function transformKeysToSnake(data: Row[]): Row[] {
   if (!data || data.length === 0) return []
   const headers = data[0] as string[]
   const transformedHeaders = headers.map(header => camelToSnake(header))

--- a/jsonjsdb-builder/test/JsonjsdbBuilder.test.ts
+++ b/jsonjsdb-builder/test/JsonjsdbBuilder.test.ts
@@ -205,6 +205,46 @@ describe('JsonjsdbBuilder E2E Tests', () => {
       await builder.updateDb(testExcelPath)
       await assertBasicFiles()
     })
+
+    it('should not regenerate when source mtime changes but content is identical', async () => {
+      const builder = await setupBuilder()
+
+      await builder.updateDb(testExcelPath)
+
+      const tableIndexPath = builder.getTableIndexFile()
+      const metaBefore = JSON.parse(await fs.readFile(tableIndexPath, 'utf-8'))
+      const userJsonBefore = await fs.readFile(
+        path.join(outputDbDir, 'user.json.js'),
+        'utf-8',
+      )
+
+      // Simulate git checkout: rewrite files to bump mtime without changing content
+      const files = await fs.readdir(testExcelPath)
+      for (const file of files) {
+        if (!file.endsWith('.xlsx')) continue
+        const filePath = path.join(testExcelPath, file)
+        const content = await fs.readFile(filePath)
+        await fs.writeFile(filePath, content)
+      }
+
+      await builder.updateDb(testExcelPath)
+
+      const metaAfter = JSON.parse(await fs.readFile(tableIndexPath, 'utf-8'))
+      const userJsonAfter = await fs.readFile(
+        path.join(outputDbDir, 'user.json.js'),
+        'utf-8',
+      )
+
+      expect(userJsonAfter).toBe(userJsonBefore)
+
+      const userBefore = metaBefore.find(
+        (r: Record<string, unknown>) => r.name === 'user',
+      )
+      const userAfter = metaAfter.find(
+        (r: Record<string, unknown>) => r.name === 'user',
+      )
+      expect(userAfter.last_modif).toBe(userBefore.last_modif)
+    })
   })
 
   describe('Markdown directory processing', () => {


### PR DESCRIPTION
Compare converted JSON output with existing output before writing. When content is identical (e.g. after git checkout bumping mtime), preserve the original last_modif and skip file writes, preventing spurious diffs in __table__.json.