### PR TITLE
fix: Avoid rewriting unchanged exports from `save()` and writer calls…

### DIFF
--- a/jsonjsdb-py/CHANGELOG.md
+++ b/jsonjsdb-py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.9
+
+fix: Avoid rewriting unchanged exports from `save()` and writer calls while preserving `__table__.last_modif` for unchanged tables
+
 ## 0.8.8
 
 fix: Stop exporting internal `parent_entity` in evolution JSON, JSON.js, and XLSX outputs

--- a/jsonjsdb-py/pyproject.toml
+++ b/jsonjsdb-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jsonjsdb"
-version = "0.8.8"
+version = "0.8.9"
 description = "Python library for JSONJS database loading"
 authors = [{ name = "datannur" }]
 readme = "README.md"

--- a/jsonjsdb-py/src/jsonjsdb/database.py
+++ b/jsonjsdb-py/src/jsonjsdb/database.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, get_args, get_type_hints
 
@@ -18,7 +19,12 @@ from .evolution import (
 from .loader import load_table, load_table_index
 from .table import Table
 from .types import TableRow
-from .writer import write_table_index, write_table_json, write_table_jsonjs
+from .writer import (
+    load_json_hashes,
+    save_json_hashes,
+    table_index_df,
+    write_table_json_pair,
+)
 
 # Internal tables that should not be loaded as user data
 INTERNAL_TABLES = {"evolution", "__table__"}
@@ -144,6 +150,10 @@ class Jsonjsdb:
 
         ts = timestamp if timestamp is not None else get_timestamp()
         new_entries: list[EvolutionEntry] = []
+        old_hashes = load_json_hashes(save_path)
+        old_last_modifs = _load_last_modifs(save_path / "__table__.json")
+        new_hashes: dict[str, str] = {}
+        last_modifs: dict[str, int] = {}
 
         table_names = []
         for name, table in self._tables.items():
@@ -151,17 +161,33 @@ class Jsonjsdb:
             if persistable_df.is_empty():
                 continue
 
-            # Track evolution if enabled
-            if track_evolution:
+            json_rel_path = f"{name}.json"
+
+            def track_table_evolution(data_changed: bool) -> None:
+                if not track_evolution or not data_changed:
+                    return
+
                 old_df = self._get_old_table(save_path, name, same_path)
                 entries = compare_datasets(
                     old_df, persistable_df, ts, name, parent_relations
                 )
                 new_entries.extend(entries)
 
-            write_table_json(persistable_df, save_path / f"{name}.json")
-            if write_js:
-                write_table_jsonjs(persistable_df, name, save_path / f"{name}.json.js")
+            write_result = write_table_json_pair(
+                persistable_df,
+                name,
+                save_path,
+                write_js=write_js,
+                export_root=save_path,
+                previous_hashes=old_hashes,
+                update_hash_metadata=False,
+                before_write=track_table_evolution,
+            )
+
+            new_hashes[json_rel_path] = write_result.json_hash
+            last_modifs[name] = (
+                ts if write_result.data_changed else old_last_modifs.get(name, ts)
+            )
             table_names.append(name)
 
             # Update snapshot for next comparison
@@ -179,10 +205,28 @@ class Jsonjsdb:
             save_evolution(all_entries, save_path, xlsx_path)
             if "evolution" not in table_names:  # pragma: no branch
                 table_names.append("evolution")
+            last_modifs["evolution"] = ts
+        elif (save_path / "evolution.json").exists():
+            table_names.append("evolution")
+            last_modifs["evolution"] = old_last_modifs.get("evolution", ts)
 
-        write_table_index(
-            table_names, save_path / "__table__.json", ts, write_js=write_js
+        last_modifs["__table__"] = (
+            ts
+            if _last_modifs_changed(last_modifs, old_last_modifs)
+            else old_last_modifs.get("__table__", ts)
         )
+        table_index = table_index_df(table_names, ts, last_modifs=last_modifs)
+        table_index_result = write_table_json_pair(
+            table_index,
+            "__table__",
+            save_path,
+            write_js=write_js,
+            export_root=save_path,
+            previous_hashes=old_hashes,
+            update_hash_metadata=False,
+        )
+        new_hashes["__table__.json"] = table_index_result.json_hash
+        save_json_hashes(save_path, _merge_json_hashes(old_hashes, new_hashes))
 
         self._path = save_path
 
@@ -199,3 +243,45 @@ class Jsonjsdb:
         if not json_path.exists():
             return pl.DataFrame()
         return load_table(json_path)
+
+
+def _merge_json_hashes(
+    old_hashes: dict[str, str], new_hashes: dict[str, str]
+) -> dict[str, str]:
+    managed_hashes = {
+        key: value
+        for key, value in old_hashes.items()
+        if key.startswith("_") or not key.endswith(".json")
+    }
+    managed_hashes.update(new_hashes)
+    return managed_hashes
+
+
+def _load_last_modifs(path: Path) -> dict[str, int]:
+    if not path.exists():
+        return {}
+
+    try:
+        entries = load_table_index(path)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+    result: dict[str, int] = {}
+    for entry in entries:
+        name = entry.get("name")
+        last_modif = entry.get("last_modif")
+        if isinstance(name, str) and isinstance(last_modif, int):
+            result[name] = last_modif
+    return result
+
+
+def _last_modifs_changed(
+    new_values: dict[str, int], old_values: dict[str, int]
+) -> bool:
+    public_new_values = {
+        key: value for key, value in new_values.items() if key != "__table__"
+    }
+    public_old_values = {
+        key: value for key, value in old_values.items() if key != "__table__"
+    }
+    return public_new_values != public_old_values

--- a/jsonjsdb-py/src/jsonjsdb/writer.py
+++ b/jsonjsdb-py/src/jsonjsdb/writer.py
@@ -1,25 +1,151 @@
 """Write Polars DataFrames to JSON and JSON.js files."""
 
+from __future__ import annotations
+
+import hashlib
 import json
 import time
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import polars as pl
 
+HASHES_PATH = Path("_meta") / "json-hashes.json"
 
-def write_table_json(df: pl.DataFrame, path: Path) -> None:
+
+@dataclass(frozen=True)
+class TableWriteResult:
+    """Result of writing a logical table export."""
+
+    data_changed: bool
+    json_written: bool
+    jsonjs_written: bool
+    json_hash: str
+
+
+def write_table_json(
+    df: pl.DataFrame, path: Path, *, export_root: Path | None = None
+) -> None:
     """Write a DataFrame to a JSON file (array of objects)."""
-    prepared_df = _prepare_df_for_write(df)
-    rows = _df_to_json_rows(prepared_df)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(rows, f, indent=2, ensure_ascii=False, allow_nan=False)
-        f.write("\n")
+    write_table_json_pair(
+        df,
+        path.stem,
+        path.parent,
+        write_js=False,
+        export_root=export_root,
+        json_path=path,
+    )
 
 
-def write_table_jsonjs(df: pl.DataFrame, table_name: str, path: Path) -> None:
+def write_table_jsonjs(
+    df: pl.DataFrame,
+    table_name: str,
+    path: Path,
+    *,
+    export_root: Path | None = None,
+) -> None:
     """Write a DataFrame to a JSON.js file (array of arrays format)."""
-    prepared_df = _prepare_df_for_write(df)
+    prepared_df = prepare_table_for_export(df)
+    json_content = table_json_content_from_prepared(prepared_df)
+    content_hash = table_json_hash_from_content(json_content)
+    if (
+        _export_hash_matches(
+            path.with_suffix(""), content_hash, export_root=export_root
+        )
+        and path.exists()
+    ):
+        return
+
+    write_text_if_changed(
+        path, table_jsonjs_content_from_prepared(prepared_df, table_name)
+    )
+    json_path = path.with_suffix("")
+    if json_path.exists() and file_hash(json_path) == content_hash:
+        _update_export_hash(json_path, content_hash, export_root=export_root)
+
+
+def write_table_json_pair(
+    df: pl.DataFrame,
+    table_name: str,
+    output_dir: Path,
+    *,
+    write_js: bool = True,
+    export_root: Path | None = None,
+    previous_hashes: dict[str, str] | None = None,
+    update_hash_metadata: bool = True,
+    before_write: Callable[[bool], None] | None = None,
+    json_path: Path | None = None,
+) -> TableWriteResult:
+    """Write .json and optional .json.js files for one logical table export."""
+    json_path = json_path or output_dir / f"{table_name}.json"
+    jsonjs_path = output_dir / f"{table_name}.json.js"
+    root, hashes, hash_key = _hash_context(json_path, export_root, previous_hashes)
+
+    prepared_df = prepare_table_for_export(df)
+    json_content = table_json_content_from_prepared(prepared_df)
+    json_hash = table_json_hash_from_content(json_content)
+    old_hash = hashes.get(hash_key) if hash_key else None
+    if old_hash is None and json_path.exists():
+        old_hash = file_hash(json_path)
+
+    data_changed = old_hash != json_hash
+    json_missing = not json_path.exists()
+    jsonjs_missing = write_js and not jsonjs_path.exists()
+
+    if before_write:
+        before_write(data_changed)
+
+    json_written = False
+    jsonjs_written = False
+    if data_changed or json_missing:
+        json_written = write_text_if_changed(json_path, json_content)
+    if write_js and (data_changed or jsonjs_missing):
+        jsonjs_written = write_text_if_changed(
+            jsonjs_path,
+            table_jsonjs_content_from_prepared(prepared_df, table_name),
+        )
+    if update_hash_metadata and root and hash_key:
+        _update_export_hash(json_path, json_hash, export_root=root)
+
+    return TableWriteResult(data_changed, json_written, jsonjs_written, json_hash)
+
+
+def table_json_content(df: pl.DataFrame) -> str:
+    """Return canonical JSON export content for a DataFrame."""
+    return table_json_content_from_prepared(prepare_table_for_export(df))
+
+
+def table_json_hash_from_content(content: str) -> str:
+    """Return the canonical JSON export hash for pre-rendered content."""
+    return _content_hash(content)
+
+
+def table_json_hash(df: pl.DataFrame) -> str:
+    """Return the canonical JSON export hash for a DataFrame."""
+    return table_json_hash_from_content(table_json_content(df))
+
+
+def table_jsonjs_content(df: pl.DataFrame, table_name: str) -> str:
+    """Return JSON.js export content for a DataFrame."""
+    return table_jsonjs_content_from_prepared(prepare_table_for_export(df), table_name)
+
+
+def prepare_table_for_export(df: pl.DataFrame) -> pl.DataFrame:
+    """Return a DataFrame normalized for JSON and JSON.js export."""
+    return _prepare_df_for_write(df)
+
+
+def table_json_content_from_prepared(prepared_df: pl.DataFrame) -> str:
+    """Return canonical JSON export content from a prepared DataFrame."""
+    rows = _df_to_json_rows(prepared_df)
+    return json.dumps(rows, indent=2, ensure_ascii=False, allow_nan=False) + "\n"
+
+
+def table_jsonjs_content_from_prepared(
+    prepared_df: pl.DataFrame, table_name: str
+) -> str:
+    """Return JSON.js export content from a prepared DataFrame."""
     columns = prepared_df.columns
     rows: list[list[Any]] = [columns]
 
@@ -29,10 +155,7 @@ def write_table_jsonjs(df: pl.DataFrame, table_name: str, path: Path) -> None:
     json_array = json.dumps(
         rows, ensure_ascii=False, separators=(",", ":"), allow_nan=False
     )
-    content = f"jsonjs.data['{table_name}'] = {json_array}\n"
-
-    with open(path, "w", encoding="utf-8") as f:
-        f.write(content)
+    return f"jsonjs.data['{table_name}'] = {json_array}\n"
 
 
 def write_table_index(
@@ -41,6 +164,7 @@ def write_table_index(
     timestamp: Optional[int] = None,
     *,
     write_js: bool = True,
+    last_modifs: dict[str, int] | None = None,
 ) -> None:
     """Write __table__.json and optionally __table__.json.js with table metadata.
 
@@ -49,14 +173,121 @@ def write_table_index(
         path: Path to write __table__.json
         timestamp: Optional timestamp override (uses current time if None)
         write_js: If True, also write __table__.json.js (default: True)
+        last_modifs: Optional per-table last_modif values to preserve
     """
+    write_table_json_pair(
+        table_index_df(tables, timestamp, last_modifs=last_modifs),
+        path.stem,
+        path.parent,
+        write_js=write_js,
+        json_path=path,
+    )
+
+
+def table_index_df(
+    tables: list[str],
+    timestamp: Optional[int] = None,
+    *,
+    last_modifs: dict[str, int] | None = None,
+) -> pl.DataFrame:
+    """Build the __table__ DataFrame."""
     now = timestamp if timestamp is not None else int(time.time())
     all_tables = sorted(tables) + ["__table__"]
-    df = pl.DataFrame([{"name": name, "last_modif": now} for name in all_tables])
+    table_rows = [
+        {"name": name, "last_modif": last_modifs.get(name, now) if last_modifs else now}
+        for name in all_tables
+    ]
+    return pl.DataFrame(table_rows)
 
-    write_table_json(df, path)
-    if write_js:
-        write_table_jsonjs(df, "__table__", path.with_suffix(".json.js"))
+
+def write_text_if_changed(path: Path, content: str) -> bool:
+    """Write text only when content differs. Return True when a write occurred."""
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return False
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def _export_hash_matches(
+    path: Path, content_hash: str, *, export_root: Path | None = None
+) -> bool:
+    """Return whether hash metadata says an export is unchanged and present."""
+    root = export_root or find_export_root(path)
+    if root is None or not path.exists():
+        return False
+
+    return load_json_hashes(root).get(export_hash_key(root, path)) == content_hash
+
+
+def _update_export_hash(
+    path: Path, content_hash: str, *, export_root: Path | None = None
+) -> None:
+    """Update hash metadata for an exported JSON file when a DB root is known."""
+    root = export_root or find_export_root(path)
+    if root is None:
+        return
+
+    hashes = load_json_hashes(root)
+    hashes[export_hash_key(root, path)] = content_hash
+    save_json_hashes(root, hashes)
+
+
+def _hash_context(
+    path: Path,
+    export_root: Path | None,
+    previous_hashes: dict[str, str] | None,
+) -> tuple[Path | None, dict[str, str], str | None]:
+    root = export_root or find_export_root(path)
+    if previous_hashes is not None:
+        hashes = previous_hashes
+    elif root:
+        hashes = load_json_hashes(root)
+    else:
+        hashes = {}
+    hash_key = export_hash_key(root, path) if root else None
+    return root, hashes, hash_key
+
+
+def load_json_hashes(root: Path) -> dict[str, str]:
+    hashes_path = root / HASHES_PATH
+    if not hashes_path.exists():
+        return {}
+
+    try:
+        with open(hashes_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+    return {str(key): str(value) for key, value in data.items()}
+
+
+def save_json_hashes(root: Path, hashes: dict[str, str]) -> None:
+    content = json.dumps(hashes, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    write_text_if_changed(root / HASHES_PATH, content)
+
+
+def find_export_root(path: Path) -> Path | None:
+    """Find the nearest parent directory that looks like a jsonjsdb export root."""
+    current = path.parent
+    for candidate in (current, *current.parents):
+        if (candidate / "__table__.json").exists():
+            return candidate
+    return None
+
+
+def export_hash_key(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def file_hash(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _content_hash(content: str) -> str:
+    return "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
 def _prepare_df_for_write(df: pl.DataFrame) -> pl.DataFrame:

--- a/jsonjsdb-py/tests/test_jsonjsdb.py
+++ b/jsonjsdb-py/tests/test_jsonjsdb.py
@@ -359,6 +359,166 @@ def test_save_with_write_js_false(tmp_path: Path):
     assert not (new_path / "user.json.js").exists()
 
 
+def test_save_without_changes_preserves_files_and_last_modif(tmp_path: Path):
+    """Should not rewrite unchanged exports on no-op save."""
+    db = TypedDB(DB_PATH)
+    db.save(tmp_path, timestamp=111)
+
+    tracked_paths = [
+        tmp_path / "user.json",
+        tmp_path / "user.json.js",
+        tmp_path / "__table__.json",
+        tmp_path / "__table__.json.js",
+    ]
+    mtimes_before = {path: path.stat().st_mtime_ns for path in tracked_paths}
+    table_index_before = json.loads((tmp_path / "__table__.json").read_text())
+
+    db.save(tmp_path, timestamp=222)
+
+    mtimes_after = {path: path.stat().st_mtime_ns for path in tracked_paths}
+    table_index_after = json.loads((tmp_path / "__table__.json").read_text())
+
+    assert mtimes_after == mtimes_before
+    assert table_index_after == table_index_before
+
+
+def test_save_without_changes_skips_evolution_comparison(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Should avoid expensive evolution comparisons for unchanged tables."""
+    import jsonjsdb.database as database_module
+
+    db = TypedDB(DB_PATH)
+    db.save(tmp_path, timestamp=111)
+
+    calls = 0
+
+    def fail_on_compare(*args: object, **kwargs: object) -> list[object]:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("compare_datasets should not run for unchanged tables")
+
+    monkeypatch.setattr(database_module, "compare_datasets", fail_on_compare)
+
+    db.save(tmp_path, timestamp=222)
+
+    assert calls == 0
+
+
+def test_save_regenerates_missing_jsonjs_for_unchanged_table(tmp_path: Path):
+    """Should rewrite derived JSON.js when canonical JSON is unchanged but JS is missing."""
+    db = TypedDB(DB_PATH)
+    db.save(tmp_path, timestamp=111)
+    user_json_mtime = (tmp_path / "user.json").stat().st_mtime_ns
+
+    (tmp_path / "user.json.js").unlink()
+
+    db.save(tmp_path, timestamp=222)
+
+    assert (tmp_path / "user.json").stat().st_mtime_ns == user_json_mtime
+    assert (tmp_path / "user.json.js").exists()
+
+
+def test_save_without_hash_state_uses_existing_json_hash(tmp_path: Path):
+    """Should avoid data changes when upgrading a database without hash metadata."""
+    db = TypedDB(DB_PATH)
+    db.save(tmp_path, timestamp=111)
+    (tmp_path / "_meta" / "json-hashes.json").unlink()
+    user_json_mtime = (tmp_path / "user.json").stat().st_mtime_ns
+
+    db.save(tmp_path, timestamp=222)
+
+    table_index = {
+        entry["name"]: entry["last_modif"]
+        for entry in json.loads((tmp_path / "__table__.json").read_text())
+    }
+    assert (tmp_path / "user.json").stat().st_mtime_ns == user_json_mtime
+    assert table_index["user"] == 111
+
+
+def test_save_with_invalid_hash_state_uses_existing_json_hash(tmp_path: Path):
+    """Should recover when hash metadata exists but cannot be decoded."""
+    db = TypedDB(DB_PATH)
+    db.save(tmp_path, timestamp=111)
+    (tmp_path / "_meta" / "json-hashes.json").write_text("{", encoding="utf-8")
+    user_json_mtime = (tmp_path / "user.json").stat().st_mtime_ns
+
+    db.save(tmp_path, timestamp=222)
+
+    table_index = {
+        entry["name"]: entry["last_modif"]
+        for entry in json.loads((tmp_path / "__table__.json").read_text())
+    }
+    assert (tmp_path / "user.json").stat().st_mtime_ns == user_json_mtime
+    assert table_index["user"] == 111
+
+
+def test_save_prunes_stale_table_hashes(tmp_path: Path):
+    """Should remove hash entries for public tables no longer exported."""
+    db = TypedDB(DB_PATH)
+    db.save(tmp_path, timestamp=111)
+
+    del db._tables["tag"]
+    db.save(tmp_path, timestamp=222)
+
+    hashes = json.loads((tmp_path / "_meta" / "json-hashes.json").read_text())
+    assert "tag.json" not in hashes
+    assert "user.json" in hashes
+    assert "__table__.json" in hashes
+
+
+def test_save_updates_last_modif_only_for_changed_tables(tmp_path: Path):
+    """Should keep previous last_modif values for unchanged table entries."""
+    db = TypedDB(DB_PATH)
+    db.save(tmp_path, timestamp=111)
+
+    db.user.update("user_1", name="Alice Updated")
+    db.save(tmp_path, timestamp=222)
+
+    table_index = {
+        entry["name"]: entry["last_modif"]
+        for entry in json.loads((tmp_path / "__table__.json").read_text())
+    }
+
+    assert table_index["user"] == 222
+    assert table_index["tag"] == 111
+    assert table_index["email"] == 111
+    assert table_index["folder"] == 111
+    assert table_index["__table__"] == 222
+
+
+def test_save_without_changes_keeps_evolution_files_untouched(tmp_path: Path):
+    """Should not rewrite evolution files when no new evolution entry is produced."""
+    db = TypedDB(DB_PATH)
+    db.save(tmp_path, timestamp=111)
+    db.user.update("user_1", name="Alice Updated")
+    db.save(tmp_path, timestamp=222)
+
+    evolution_paths = [tmp_path / "evolution.json", tmp_path / "evolution.json.js"]
+    mtimes_before = {path: path.stat().st_mtime_ns for path in evolution_paths}
+
+    db.save(tmp_path, timestamp=333)
+
+    mtimes_after = {path: path.stat().st_mtime_ns for path in evolution_paths}
+
+    assert mtimes_after == mtimes_before
+
+
+def test_save_recovers_from_invalid_existing_table_index(tmp_path: Path):
+    """Should save even when an existing target __table__.json is invalid."""
+    db = TypedDB()
+    db.user.add({"id": "u1", "name": "User", "status": "active", "tag_ids": []})
+    (tmp_path / "__table__.json").write_text("{", encoding="utf-8")
+
+    db.save(tmp_path, timestamp=111, track_evolution=False)
+
+    table_index = json.loads((tmp_path / "__table__.json").read_text())
+    assert table_index == [
+        {"name": "user", "last_modif": 111},
+        {"name": "__table__", "last_modif": 111},
+    ]
+
+
 def test_save_and_reload(tmp_path: Path):
     """Should save and reload database correctly."""
     # Create and save
@@ -1549,6 +1709,148 @@ def test_schema_less_dataframe_writer_preserves_integer_and_float_dtypes(
     assert js_rows[1][2] == 1.0
     assert js_rows[2][1] is None
     assert js_rows[2][2] is None
+
+
+def test_dataframe_writers_do_not_touch_identical_files(tmp_path: Path):
+    """Should avoid rewriting identical JSON and JSON.js content."""
+    from jsonjsdb.writer import write_table_json, write_table_jsonjs
+
+    df = pl.DataFrame({"id": ["row-1"], "name": ["Alpha"]})
+    json_path = tmp_path / "data.json"
+    jsonjs_path = tmp_path / "data.json.js"
+
+    write_table_json(df, json_path)
+    write_table_jsonjs(df, "data", jsonjs_path)
+    mtimes_before = {
+        json_path: json_path.stat().st_mtime_ns,
+        jsonjs_path: jsonjs_path.stat().st_mtime_ns,
+    }
+
+    write_table_json(df, json_path)
+    write_table_jsonjs(df, "data", jsonjs_path)
+
+    mtimes_after = {
+        json_path: json_path.stat().st_mtime_ns,
+        jsonjs_path: jsonjs_path.stat().st_mtime_ns,
+    }
+
+    assert mtimes_after == mtimes_before
+
+
+def test_json_writer_preserves_exact_output_path(tmp_path: Path):
+    """Should write exactly the requested JSON path when called directly."""
+    from jsonjsdb.writer import write_table_json
+
+    df = pl.DataFrame({"id": ["row-1"], "name": ["Alpha"]})
+    json_path = tmp_path / "guide.data.json"
+
+    write_table_json(df, json_path)
+
+    assert json_path.exists()
+    assert not (tmp_path / "guide.data.data.json").exists()
+
+
+def test_dataframe_writers_update_hashes_for_nested_exports(tmp_path: Path):
+    """Should track unchanged direct writer exports under the DB root."""
+    from jsonjsdb.writer import write_table_json, write_table_jsonjs
+
+    (tmp_path / "__table__.json").write_text("[]", encoding="utf-8")
+    df = pl.DataFrame({"id": ["doc-1"], "title": ["Guide"]})
+    json_path = tmp_path / "md-doc" / "guide.json"
+    jsonjs_path = tmp_path / "md-doc" / "guide.json.js"
+
+    write_table_json(df, json_path)
+    write_table_jsonjs(df, "md-doc/guide", jsonjs_path)
+
+    hashes = json.loads((tmp_path / "_meta" / "json-hashes.json").read_text())
+    assert hashes["md-doc/guide.json"].startswith("sha256:")
+
+    mtimes_before = {
+        json_path: json_path.stat().st_mtime_ns,
+        jsonjs_path: jsonjs_path.stat().st_mtime_ns,
+    }
+
+    write_table_json(df, json_path)
+    write_table_jsonjs(df, "md-doc/guide", jsonjs_path)
+
+    mtimes_after = {
+        json_path: json_path.stat().st_mtime_ns,
+        jsonjs_path: jsonjs_path.stat().st_mtime_ns,
+    }
+    assert mtimes_after == mtimes_before
+
+
+def test_pair_writer_reports_changes_for_nested_exports(tmp_path: Path):
+    """Should write paired JSON exports and report logical data changes."""
+    from jsonjsdb.writer import write_table_json_pair
+
+    (tmp_path / "__table__.json").write_text("[]", encoding="utf-8")
+    df = pl.DataFrame({"id": ["doc-1"], "title": ["Guide"]})
+
+    first_result = write_table_json_pair(df, "md-doc/guide", tmp_path)
+    second_result = write_table_json_pair(df, "md-doc/guide", tmp_path)
+
+    assert first_result.data_changed is True
+    assert first_result.json_written is True
+    assert first_result.jsonjs_written is True
+    assert second_result.data_changed is False
+    assert second_result.json_written is False
+    assert second_result.jsonjs_written is False
+    assert (tmp_path / "md-doc" / "guide.json").exists()
+    assert (tmp_path / "md-doc" / "guide.json.js").exists()
+
+
+def test_pair_writer_works_without_export_root(tmp_path: Path):
+    """Should still write paired exports when no DB root metadata is present."""
+    from jsonjsdb.writer import table_jsonjs_content, write_table_json_pair
+
+    df = pl.DataFrame({"id": ["doc-1"], "title": ["Guide"]})
+    result = write_table_json_pair(df, "guide", tmp_path)
+
+    assert result.data_changed is True
+    assert table_jsonjs_content(df, "guide").startswith("jsonjs.data['guide'] = ")
+    assert not (tmp_path / "_meta" / "json-hashes.json").exists()
+
+
+def test_jsonjs_writer_does_not_poison_hash_before_json(tmp_path: Path):
+    """Should not mark canonical JSON unchanged before the JSON file is updated."""
+    from jsonjsdb.writer import write_table_json, write_table_jsonjs
+
+    (tmp_path / "__table__.json").write_text("[]", encoding="utf-8")
+    json_path = tmp_path / "md-doc" / "guide.json"
+    jsonjs_path = tmp_path / "md-doc" / "guide.json.js"
+
+    old_df = pl.DataFrame({"id": ["doc-1"], "title": ["Old"]})
+    new_df = pl.DataFrame({"id": ["doc-1"], "title": ["New"]})
+    write_table_json(old_df, json_path)
+
+    write_table_jsonjs(new_df, "md-doc/guide", jsonjs_path)
+    write_table_json(new_df, json_path)
+
+    rows = json.loads(json_path.read_text())
+    assert rows == [{"id": "doc-1", "title": "New"}]
+
+
+def test_writer_hash_and_table_index_helpers(tmp_path: Path):
+    """Should expose hash and table index helpers with preserved last_modif values."""
+    from jsonjsdb.writer import table_json_hash, write_table_index
+
+    df = pl.DataFrame({"id": ["row-1"], "name": ["Alpha"]})
+    assert table_json_hash(df).startswith("sha256:")
+
+    write_table_index(
+        ["data"],
+        tmp_path / "__table__.json",
+        timestamp=222,
+        last_modifs={"data": 111, "__table__": 222},
+    )
+
+    table_index = json.loads((tmp_path / "__table__.json").read_text())
+    assert table_index == [
+        {"name": "data", "last_modif": 111},
+        {"name": "__table__", "last_modif": 222},
+    ]
+    assert (tmp_path / "__table__.json.js").exists()
 
 
 def test_load_nullable_column_with_late_value(tmp_path: Path):

--- a/jsonjsdb-py/uv.lock
+++ b/jsonjsdb-py/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "jsonjsdb"
-version = "0.8.8"
+version = "0.8.9"
 source = { editable = "." }
 dependencies = [
     { name = "openpyxl" },


### PR DESCRIPTION
… while preserving `__table__.last_modif` for unchanged tables