### PR TITLE
add: Table.get_many() and upsert_all() for partial reads and batch up…

### DIFF
--- a/jsonjsdb-py/CHANGELOG.md
+++ b/jsonjsdb-py/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.0
+
+add: `Table.get_many(ids)` to reconstruct only the requested rows instead of `all()`
+add: `Table.upsert_all(rows)` for insert-or-replace in a single rebuild, preserving row position and runtime fields
+
 ## 0.8.11
 
 fix: Preserve composite evolution entry names when the first ID column contains the `---` separator and the second column is empty

--- a/jsonjsdb-py/README.md
+++ b/jsonjsdb-py/README.md
@@ -89,8 +89,10 @@ table.add(User(id="u2", name="Bob", tag_ids=[]))
 db.user.add({"id": "u1", "name": "Alice", ...})  # Add row (id required)
 db.user.add_all([...])                           # Add multiple rows (batch)
 db.user.upsert({"id": "u1", ...})                # Add or update → bool (True=added)
+db.user.upsert_all([...])                        # Insert-or-replace multiple rows (single rebuild)
 
 db.user.get("u1")                                # → User | None
+db.user.get_many(["u1", "u2"])                   # → list[User] (only requested rows)
 db.user.get_by("email", "alice@test.com")        # → User | None (by column)
 db.user.exists("u1")                             # → bool
 db.user.all()                                    # → list[User]

--- a/jsonjsdb-py/pyproject.toml
+++ b/jsonjsdb-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jsonjsdb"
-version = "0.8.11"
+version = "0.9.0"
 description = "Python library for JSONJS database loading"
 authors = [{ name = "datannur" }]
 readme = "README.md"

--- a/jsonjsdb-py/src/jsonjsdb/table.py
+++ b/jsonjsdb-py/src/jsonjsdb/table.py
@@ -131,6 +131,18 @@ class Table(Generic[T]):
         results = self.where(column, "==", value)
         return results[0] if results else None
 
+    def get_many(self, ids: list[ID]) -> list[T]:
+        """Get multiple rows by ID as entities.
+
+        Reconstructs only the requested rows (K entities) instead of all() (N).
+        IDs that are not present are simply absent from the result; the order of
+        the result follows the table, not ``ids``.
+        """
+        if self._df.is_empty() or "id" not in self._df.columns:
+            return []
+        sub = self._df.filter(pl.col("id").is_in(ids))
+        return [self._row_to_entity(row) for row in sub.iter_rows(named=True)]
+
     def all(self) -> list[T]:
         """Get all rows as a list of entities."""
         return [self._row_to_entity(row) for row in self._df.iter_rows(named=True)]
@@ -290,6 +302,54 @@ class Table(Generic[T]):
             self._df = new_df
         else:
             self._df = pl.concat([self._df, new_df], how="diagonal_relaxed")
+
+    def upsert_all(self, rows: list[T]) -> None:
+        """Insert-or-replace multiple rows in a single rebuild.
+
+        For each row, replaces the existing row with the same id (preserving its
+        position in the table) or inserts it (appended at the end) when the id is
+        new. A single insert-or-replace instead of remove_all + add_all.
+
+        The incoming batch is validated like add_all (each row needs an 'id', no
+        duplicate id *within the batch*) — but an id already present in the table
+        is expected and triggers a replacement, not an error.
+
+        runtime_fields columns that are absent from the incoming rows are
+        preserved on replaced rows.
+        """
+        if not rows:
+            return
+
+        dicts = [self._entity_to_dict(r) for r in rows]
+        for d in dicts:
+            if "id" not in d:
+                raise ValueError("Row must have an 'id' field")
+
+        incoming_ids = [str(d["id"]) for d in dicts]
+        if len(set(incoming_ids)) != len(incoming_ids):
+            raise ValueError("Duplicate IDs in rows to upsert")
+
+        prepared = [self._prepare_row_for_storage(d) for d in dicts]
+        new_df = self._apply_storage_schema(
+            pl.DataFrame(prepared, infer_schema_length=None)
+        )
+
+        if self._df.is_empty():
+            self._df = new_df
+            return
+
+        # Add any columns introduced by the batch so update() keeps them
+        # (update with how="full" only retains columns present on the left).
+        base = self._df
+        new_columns = [c for c in new_df.columns if c not in base.columns]
+        if new_columns:
+            base = base.with_columns(
+                pl.lit(None).cast(new_df.schema[c]).alias(c) for c in new_columns
+            )
+
+        self._df = base.update(  # type: ignore[attr-defined]
+            new_df, on="id", how="full", include_nulls=True
+        )
 
     def update(self, id: ID, **kwargs: Any) -> None:
         """Update a row by ID. Raises KeyError if not found."""

--- a/jsonjsdb-py/tests/test_jsonjsdb.py
+++ b/jsonjsdb-py/tests/test_jsonjsdb.py
@@ -267,6 +267,108 @@ def test_add_all():
     assert len(db["tag"].all()) == initial_count + 2
 
 
+def test_get_many():
+    """Should reconstruct only the requested rows, in table order."""
+    db = Jsonjsdb(DB_PATH)
+    users = db["user"].get_many(["user_3", "user_1", "nonexistent"])
+    assert [u["id"] for u in users] == ["user_1", "user_3"]
+
+
+def test_get_many_empty_ids():
+    """Should return empty list for no matches."""
+    db = Jsonjsdb(DB_PATH)
+    assert db["user"].get_many([]) == []
+    assert db["user"].get_many(["nope"]) == []
+
+
+def test_get_many_empty_table():
+    """Should return empty list on an empty table."""
+    table: Table[dict] = Table("empty")
+    assert table.get_many(["x"]) == []
+
+
+def test_upsert_all_inserts_and_replaces():
+    """Should replace existing rows in place and append new ones."""
+    db = Jsonjsdb(DB_PATH)
+    db["tag"].upsert_all(
+        [
+            {"id": "tag_1", "label": "Relabelled"},
+            {"id": "tag_new", "label": "Brand New"},
+        ]
+    )
+
+    assert db["tag"].get("tag_1")["label"] == "Relabelled"  # type: ignore[index]
+    assert db["tag"].get("tag_new")["label"] == "Brand New"  # type: ignore[index]
+
+
+def test_upsert_all_preserves_row_order():
+    """Replaced rows keep their original position; new rows go last."""
+    db = Jsonjsdb(DB_PATH)
+    original_ids = db["user"].df["id"].to_list()
+
+    db["user"].upsert_all(
+        [
+            {"id": "user_2", "name": "Bob 2", "status": "active", "tag_ids": []},
+            {"id": "user_z", "name": "Zed", "status": "active", "tag_ids": []},
+        ]
+    )
+
+    assert db["user"].df["id"].to_list() == original_ids + ["user_z"]
+    assert db["user"].get("user_2")["name"] == "Bob 2"  # type: ignore[index]
+
+
+def test_upsert_all_introduces_new_column():
+    """A column present only in the batch should be added to the table."""
+    import polars as pl
+
+    table: Table[dict] = Table("item")
+    table._df = pl.DataFrame([{"id": "1", "name": "One"}])
+
+    table.upsert_all(
+        [{"id": "1", "name": "One", "score": 5}, {"id": "2", "name": "Two", "score": 9}]
+    )
+
+    assert "score" in table.df.columns
+    assert table.get("1") == {"id": "1", "name": "One", "score": 5}
+    assert table.get("2") == {"id": "2", "name": "Two", "score": 9}
+
+
+def test_upsert_all_duplicate_in_batch_raises():
+    """Should raise on duplicate id within the incoming batch."""
+    db = Jsonjsdb(DB_PATH)
+    with pytest.raises(ValueError, match="Duplicate IDs"):
+        db["tag"].upsert_all(
+            [{"id": "tag_1", "label": "A"}, {"id": "tag_1", "label": "B"}]
+        )
+
+
+def test_upsert_all_missing_id_raises():
+    """Should raise when a row lacks an id."""
+    db = Jsonjsdb(DB_PATH)
+    with pytest.raises(ValueError, match="must have an 'id'"):
+        db["tag"].upsert_all([{"label": "No ID"}])  # type: ignore[list-item]
+
+
+def test_upsert_all_into_empty_table():
+    """Should populate an empty table."""
+    db = Jsonjsdb(DB_PATH)
+    db["user"].remove_all(db["user"].df["id"].to_list())
+    assert db["user"].is_empty
+
+    db["user"].upsert_all(
+        [{"id": "user_1", "name": "Alice", "status": "active", "tag_ids": []}]
+    )
+    assert db["user"].get("user_1")["name"] == "Alice"  # type: ignore[index]
+
+
+def test_upsert_all_empty_is_noop():
+    """Should do nothing for an empty batch."""
+    db = Jsonjsdb(DB_PATH)
+    before = db["user"].df["id"].to_list()
+    db["user"].upsert_all([])
+    assert db["user"].df["id"].to_list() == before
+
+
 def test_update_row():
     """Should update an existing row."""
     db = Jsonjsdb(DB_PATH)
@@ -997,6 +1099,27 @@ def test_runtime_fields_excluded_on_save(tmp_path: Path):
     assert saved[0]["name"] == "Test"
     assert "_seen" not in saved[0]
     assert "_processed" not in saved[0]
+
+
+def test_upsert_all_preserves_runtime_fields():
+    """Replacing a row keeps its runtime_fields when the batch omits them."""
+    import polars as pl
+
+    class ItemTable(Table[dict]):
+        runtime_fields = {"_seen"}
+
+    table = ItemTable("item")
+    table._df = pl.DataFrame(
+        [
+            {"id": "1", "name": "One", "_seen": True},
+            {"id": "2", "name": "Two", "_seen": True},
+        ]
+    )
+
+    table.upsert_all([{"id": "1", "name": "One*"}, {"id": "3", "name": "Three"}])
+
+    assert table.get("1") == {"id": "1", "name": "One*", "_seen": True}
+    assert table.get("3") == {"id": "3", "name": "Three", "_seen": None}
 
 
 def test_runtime_fields_empty_set():


### PR DESCRIPTION
…serts (0.9.0)

- get_many(ids): reconstruct only requested rows instead of all()
- upsert_all(rows): insert-or-replace in a single rebuild, preserving row position and runtime fields