### PR TITLE
fix: Serialize numeric list columns (e.g. `bbox`) as native JSON arra…

### DIFF
--- a/jsonjsdb-py/CHANGELOG.md
+++ b/jsonjsdb-py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+fix: Serialize numeric list columns (e.g. `bbox`) as native JSON arrays instead of comma-separated strings; `List(Utf8)` columns (e.g. `*_ids`) stay CSV-encoded. NaN inside float lists is written as `null`.
+
 ## 0.9.0
 
 add: `Table.get_many(ids)` to reconstruct only the requested rows instead of `all()`

--- a/jsonjsdb-py/pyproject.toml
+++ b/jsonjsdb-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jsonjsdb"
-version = "0.9.0"
+version = "0.9.1"
 description = "Python library for JSONJS database loading"
 authors = [{ name = "datannur" }]
 readme = "README.md"

--- a/jsonjsdb-py/src/jsonjsdb/writer.py
+++ b/jsonjsdb-py/src/jsonjsdb/writer.py
@@ -307,20 +307,35 @@ def _content_hash(content: str) -> str:
 
 
 def _prepare_df_for_write(df: pl.DataFrame) -> pl.DataFrame:
-    """Prepare DataFrame for writing: convert List columns to comma-separated strings
-    and NaN to null for valid JSON output."""
+    """Prepare DataFrame for writing for valid JSON output:
+
+    - List(Utf8) columns (e.g. ``*_ids``) -> comma-separated string;
+    - other List columns (numeric, e.g. ``bbox``) -> native JSON array, with NaN
+      inside float lists replaced by null;
+    - float columns -> NaN replaced by null.
+    """
     transforms: list[pl.Expr] = []
 
     for col_name in df.columns:
         col_type = df.schema[col_name]
         if isinstance(col_type, pl.List):
-            transforms.append(
-                pl.col(col_name)
-                .cast(pl.List(pl.Utf8))
-                .list.join(",")
-                .fill_null("")
-                .alias(col_name)
-            )
+            if col_type.inner == pl.Utf8:  # string lists (e.g. *_ids) -> CSV
+                transforms.append(
+                    pl.col(col_name)
+                    .cast(pl.List(pl.Utf8))
+                    .list.join(",")
+                    .fill_null("")
+                    .alias(col_name)
+                )
+            elif col_type.inner is not None and col_type.inner.is_float():
+                # numeric float lists (e.g. bbox) -> JSON array, NaN -> null
+                transforms.append(
+                    pl.col(col_name)
+                    .list.eval(pl.element().fill_nan(None))
+                    .alias(col_name)
+                )
+            else:  # numeric (integer) lists -> native JSON array
+                transforms.append(pl.col(col_name))
         elif col_type.is_float():
             transforms.append(pl.col(col_name).fill_nan(None))
         else:

--- a/jsonjsdb-py/tests/test_jsonjsdb.py
+++ b/jsonjsdb-py/tests/test_jsonjsdb.py
@@ -2284,6 +2284,24 @@ def test_numeric_list_written_as_json_array(tmp_path: Path):
     assert js_rows[1][1] == [6.02, 45.8, 10.5, 47.8]
 
 
+def test_integer_list_written_as_json_array(tmp_path: Path):
+    """Should write List(Int64) columns as JSON arrays, not CSV."""
+    from jsonjsdb.writer import write_table_json
+
+    df = pl.DataFrame(
+        {
+            "id": ["row-1"],
+            "years": pl.Series([[2020, 2021, 2022]], dtype=pl.List(pl.Int64)),
+        }
+    )
+
+    write_table_json(df, tmp_path / "data.json")
+
+    rows = json.loads((tmp_path / "data.json").read_text())
+    assert rows[0]["years"] == [2020, 2021, 2022]
+    assert all(isinstance(v, int) for v in rows[0]["years"])
+
+
 def test_string_list_still_written_as_csv(tmp_path: Path):
     """Should keep List(Utf8) columns (e.g. *_ids) as comma-separated strings."""
     from jsonjsdb.writer import write_table_json

--- a/jsonjsdb-py/tests/test_jsonjsdb.py
+++ b/jsonjsdb-py/tests/test_jsonjsdb.py
@@ -2257,3 +2257,86 @@ def test_load_nullable_column_with_late_value(tmp_path: Path):
     assert len(all_rows) == 120
     assert all_rows[110]["key"] == 1
     assert all_rows[0]["key"] is None
+
+
+# --- Numeric list serialization (bbox) ---
+
+
+def test_numeric_list_written_as_json_array(tmp_path: Path):
+    """Should write List(Float64) columns (e.g. bbox) as JSON arrays, not CSV."""
+    from jsonjsdb.writer import write_table_json, write_table_jsonjs
+
+    df = pl.DataFrame(
+        {
+            "id": ["dataset-1"],
+            "bbox": pl.Series([[6.02, 45.8, 10.5, 47.8]], dtype=pl.List(pl.Float64)),
+        }
+    )
+
+    write_table_json(df, tmp_path / "data.json")
+    write_table_jsonjs(df, "data", tmp_path / "data.json.js")
+
+    rows = json.loads((tmp_path / "data.json").read_text())
+    assert rows[0]["bbox"] == [6.02, 45.8, 10.5, 47.8]
+    assert isinstance(rows[0]["bbox"], list)
+
+    js_rows = _load_jsonjs_payload(tmp_path / "data.json.js", "data")
+    assert js_rows[1][1] == [6.02, 45.8, 10.5, 47.8]
+
+
+def test_string_list_still_written_as_csv(tmp_path: Path):
+    """Should keep List(Utf8) columns (e.g. *_ids) as comma-separated strings."""
+    from jsonjsdb.writer import write_table_json
+
+    df = pl.DataFrame(
+        {
+            "id": ["row-1"],
+            "tag_ids": pl.Series([["a", "b", "c"]], dtype=pl.List(pl.Utf8)),
+        }
+    )
+
+    write_table_json(df, tmp_path / "data.json")
+
+    rows = json.loads((tmp_path / "data.json").read_text())
+    assert rows[0]["tag_ids"] == "a,b,c"
+
+
+def test_numeric_list_round_trip(tmp_path: Path):
+    """Should preserve numeric lists as List(Float64) and *_ids as List(Utf8)."""
+    from jsonjsdb.loader import load_table
+    from jsonjsdb.writer import write_table_json
+
+    df = pl.DataFrame(
+        {
+            "id": ["row-1"],
+            "bbox": pl.Series([[6.02, 45.8, 10.5, 47.8]], dtype=pl.List(pl.Float64)),
+            "tag_ids": pl.Series([["a", "b", "c"]], dtype=pl.List(pl.Utf8)),
+        }
+    )
+
+    write_table_json(df, tmp_path / "data.json")
+    loaded = load_table(tmp_path / "data.json")
+
+    assert loaded.schema["bbox"] == pl.List(pl.Float64)
+    assert loaded["bbox"].to_list() == [[6.02, 45.8, 10.5, 47.8]]
+    assert loaded.schema["tag_ids"] == pl.List(pl.Utf8)
+    assert loaded["tag_ids"].to_list() == [["a", "b", "c"]]
+
+
+def test_nan_in_numeric_list_becomes_null(tmp_path: Path):
+    """Should replace NaN inside a float list with null for valid JSON."""
+    from jsonjsdb.writer import write_table_json
+
+    df = pl.DataFrame(
+        {
+            "id": ["row-1"],
+            "bbox": pl.Series(
+                [[6.02, float("nan"), 10.5, 47.8]], dtype=pl.List(pl.Float64)
+            ),
+        }
+    )
+
+    write_table_json(df, tmp_path / "data.json")
+
+    rows = json.loads((tmp_path / "data.json").read_text())
+    assert rows[0]["bbox"] == [6.02, None, 10.5, 47.8]

--- a/jsonjsdb-py/uv.lock
+++ b/jsonjsdb-py/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "jsonjsdb"
-version = "0.8.11"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "openpyxl" },


### PR DESCRIPTION
…ys instead of comma-separated strings; `List(Utf8)` columns (e.g. `*_ids`) stay CSV-encoded. NaN inside float lists is written as `null`.