### PR TITLE
perf: Buffer Table inserts so repeated appends are linear (0.9.2)

### DIFF
--- a/jsonjsdb-py/CHANGELOG.md
+++ b/jsonjsdb-py/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.2
+
+perf: Buffer `Table.add()` / `add_all()` / `upsert()` inserts into a single concat — repeated appends are linear, not quadratic (~140x on a 2000-dataset scan)
+fix: `Table.upsert_all()` appended new ids in a nondeterministic order, so identical data could save to different `.json` files and hashes
+fix: `save()` silently split a string list value containing a comma into several on reload; it now raises, before writing anything
+
 ## 0.9.1
 
 fix: Serialize numeric list columns (e.g. `bbox`) as native JSON arrays instead of comma-separated strings; `List(Utf8)` columns (e.g. `*_ids`) stay CSV-encoded. NaN inside float lists is written as `null`.

--- a/jsonjsdb-py/pyproject.toml
+++ b/jsonjsdb-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jsonjsdb"
-version = "0.9.1"
+version = "0.9.2"
 description = "Python library for JSONJS database loading"
 authors = [{ name = "datannur" }]
 readme = "README.md"

--- a/jsonjsdb-py/src/jsonjsdb/database.py
+++ b/jsonjsdb-py/src/jsonjsdb/database.py
@@ -24,6 +24,7 @@ from .writer import (
     load_json_hashes,
     save_json_hashes,
     table_index_df,
+    validate_df_for_write,
     write_table_json_pair,
 )
 
@@ -141,6 +142,11 @@ class Jsonjsdb:
             raise ValueError(
                 "No path specified. Provide a path or load from an existing database first."
             )
+
+        # Reject unrepresentable data up front: a table failing halfway through
+        # would leave the export half rewritten.
+        for table in self._tables.values():
+            validate_df_for_write(table.get_persistable_df())
 
         save_path.mkdir(parents=True, exist_ok=True)
 

--- a/jsonjsdb-py/src/jsonjsdb/table.py
+++ b/jsonjsdb-py/src/jsonjsdb/table.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import math
 import types
 from typing import (
     TYPE_CHECKING,
@@ -43,6 +44,12 @@ class Table(Generic[T]):
 
     Use runtime_fields to specify columns that should exist in memory
     but never be persisted to JSON files.
+
+    Appended rows are buffered in ``_pending`` and materialized into ``_df`` by a
+    single concat on the next read or non-append mutation, which keeps repeated
+    ``add``/``add_all`` calls linear instead of quadratic. Every method that is
+    not a pure append calls ``_flush()`` first, so buffering is invisible to
+    callers.
     """
 
     runtime_fields: set[str] = set()
@@ -62,6 +69,10 @@ class Table(Generic[T]):
         self._storage_schema = _storage_schema_from_entity_type(entity_type)
         if self._storage_schema:
             self._df = self._apply_storage_schema(self._df)
+        self._pending: list[dict[str, Any]] = []
+        self._id_set: set[str] = self._ids_from_df()
+        self._pending_types: dict[str, type] = {}
+        self._pending_samples: dict[str, Any] = {}
         if runtime_fields is not None:
             self.runtime_fields = runtime_fields
         elif type(self).runtime_fields is not Table.runtime_fields:
@@ -69,26 +80,57 @@ class Table(Generic[T]):
         else:
             self.runtime_fields = set()
 
+    def _ids_from_df(self) -> set[str]:
+        if self._df.is_empty() or "id" not in self._df.columns:
+            return set()
+        return {str(value) for value in self._df["id"].to_list()}
+
+    def _flush(self) -> None:
+        """Materialize buffered appends into _df with a single concat.
+
+        _pending is cleared only once the concat has succeeded, so a flush that
+        somehow raises leaves the table readable rather than dropping the buffer
+        while _id_set still claims those ids exist.
+        """
+        if not self._pending:
+            return
+
+        new_df = self._apply_storage_schema(
+            pl.DataFrame(self._pending, infer_schema_length=None)
+        )
+
+        if self._df.is_empty():
+            self._df = new_df
+        else:
+            self._df = pl.concat([self._df, new_df], how="diagonal_relaxed")
+        self._pending = []
+        self._pending_types = {}
+        self._pending_samples = {}
+
     @property
     def name(self) -> str:
         return self._name
 
     @property
     def df(self) -> pl.DataFrame:
+        self._flush()
         return self._df
 
     @property
     def count(self) -> int:
         """Number of rows in the table."""
+        self._flush()
         return self._df.height
 
     @property
     def is_empty(self) -> bool:
         """Whether the table has no rows."""
+        self._flush()
         return self._df.is_empty()
 
     def get_persistable_df(self) -> pl.DataFrame:
         """Return DataFrame with runtime_fields columns excluded."""
+        self._flush()
         if not self.runtime_fields:
             return self._df
 
@@ -113,6 +155,7 @@ class Table(Generic[T]):
 
     def get(self, id: ID) -> T | None:
         """Get a single row by ID, or None if not found."""
+        self._flush()
         if self._df.is_empty() or "id" not in self._df.columns:
             return None
         result = self._df.filter(pl.col("id") == id)
@@ -122,6 +165,7 @@ class Table(Generic[T]):
 
     def exists(self, id: ID) -> bool:
         """Check if a row with the given ID exists."""
+        self._flush()
         if self._df.is_empty() or "id" not in self._df.columns:
             return False
         return not self._df.filter(pl.col("id") == id).is_empty()
@@ -138,6 +182,7 @@ class Table(Generic[T]):
         IDs that are not present are simply absent from the result; the order of
         the result follows the table, not ``ids``.
         """
+        self._flush()
         if self._df.is_empty() or "id" not in self._df.columns:
             return []
         sub = self._df.filter(pl.col("id").is_in(ids))
@@ -145,6 +190,7 @@ class Table(Generic[T]):
 
     def all(self) -> list[T]:
         """Get all rows as a list of entities."""
+        self._flush()
         return [self._row_to_entity(row) for row in self._df.iter_rows(named=True)]
 
     @overload
@@ -158,6 +204,7 @@ class Table(Generic[T]):
 
         Operators: ==, !=, >, >=, <, <=, in, is_null, is_not_null
         """
+        self._flush()
         if self._df.is_empty() or column not in self._df.columns:
             return []
         col = pl.col(column)
@@ -192,6 +239,7 @@ class Table(Generic[T]):
 
         More efficient than [x.id for x in table.where(...)] when only IDs are needed.
         """
+        self._flush()
         if self._df.is_empty() or column not in self._df.columns:
             return []
         col = pl.col(column)
@@ -244,19 +292,14 @@ class Table(Generic[T]):
             raise ValueError("Row must have an 'id' field")
 
         row_id = str(row_dict["id"])
-        if (
-            not self._df.is_empty()
-            and not self._df.filter(pl.col("id") == row_id).is_empty()
-        ):
+        if row_id in self._id_set:
             raise ValueError(f"Row with id '{row_id}' already exists")
 
         prepared = self._prepare_row_for_storage(row_dict)
-        new_df = self._apply_storage_schema(pl.DataFrame([prepared]))
+        self._validate_rows_for_storage([prepared])
 
-        if self._df.is_empty():
-            self._df = new_df
-        else:
-            self._df = pl.concat([self._df, new_df], how="diagonal_relaxed")
+        self._pending.append(prepared)
+        self._id_set.add(row_id)
 
     def upsert(self, row: T) -> bool:
         """Add or update a row. Returns True if added, False if updated."""
@@ -265,12 +308,14 @@ class Table(Generic[T]):
             raise ValueError("Row must have an 'id' field")
 
         row_id = str(row_dict["id"])
-        if self.exists(row_id):
-            self.update(row_id, **{k: v for k, v in row_dict.items() if k != "id"})
-            return False
-        else:
+        # _id_set covers _df and _pending, so absence is decisive: insert-only
+        # upsert loops stay buffered instead of flushing on every call.
+        if row_id not in self._id_set:
             self.add(row)
             return True
+
+        self.update(row_id, **{k: v for k, v in row_dict.items() if k != "id"})
+        return False
 
     def add_all(self, rows: list[T]) -> None:
         """Add multiple rows in a single batch operation."""
@@ -287,21 +332,15 @@ class Table(Generic[T]):
         if len(new_ids) != len(dicts):
             raise ValueError("Duplicate IDs in rows to add")
 
-        if not self._df.is_empty():
-            existing = set(self._df["id"].to_list())
-            conflicts = new_ids & existing
-            if conflicts:
-                raise ValueError(f"IDs already exist: {conflicts}")
+        conflicts = new_ids & self._id_set
+        if conflicts:
+            raise ValueError(f"IDs already exist: {conflicts}")
 
         prepared = [self._prepare_row_for_storage(d) for d in dicts]
-        new_df = self._apply_storage_schema(
-            pl.DataFrame(prepared, infer_schema_length=None)
-        )
+        self._validate_rows_for_storage(prepared)
 
-        if self._df.is_empty():
-            self._df = new_df
-        else:
-            self._df = pl.concat([self._df, new_df], how="diagonal_relaxed")
+        self._pending.extend(prepared)
+        self._id_set |= new_ids
 
     def upsert_all(self, rows: list[T]) -> None:
         """Insert-or-replace multiple rows in a single rebuild.
@@ -329,17 +368,20 @@ class Table(Generic[T]):
         if len(set(incoming_ids)) != len(incoming_ids):
             raise ValueError("Duplicate IDs in rows to upsert")
 
+        self._flush()
         prepared = [self._prepare_row_for_storage(d) for d in dicts]
         new_df = self._apply_storage_schema(
             pl.DataFrame(prepared, infer_schema_length=None)
         )
+        already_present = self._id_set & set(incoming_ids)
+        self._id_set |= set(incoming_ids)
 
         if self._df.is_empty():
             self._df = new_df
             return
 
         # Add any columns introduced by the batch so update() keeps them
-        # (update with how="full" only retains columns present on the left).
+        # (update only retains columns present on the left).
         base = self._df
         new_columns = [c for c in new_df.columns if c not in base.columns]
         if new_columns:
@@ -347,12 +389,22 @@ class Table(Generic[T]):
                 pl.lit(None).cast(new_df.schema[c]).alias(c) for c in new_columns
             )
 
-        self._df = base.update(  # type: ignore[attr-defined]
-            new_df, on="id", how="full", include_nulls=True
+        # Replace in place, then append the new ids in batch order. update(how="full")
+        # would do both at once, but it appends its right-only rows in join order,
+        # which is not deterministic — and row order reaches save() and its hashes.
+        replaced = base.update(  # type: ignore[attr-defined]
+            new_df, on="id", how="left", include_nulls=True
+        )
+        inserted = new_df.filter(~pl.col("id").is_in(list(already_present)))
+        self._df = (
+            replaced
+            if inserted.is_empty()
+            else pl.concat([replaced, inserted], how="diagonal_relaxed")
         )
 
     def update(self, id: ID, **kwargs: Any) -> None:
         """Update a row by ID. Raises KeyError if not found."""
+        self._flush()
         if self._df.is_empty() or self._df.filter(pl.col("id") == id).is_empty():
             raise KeyError(f"Row with id '{id}' not found")
 
@@ -369,10 +421,13 @@ class Table(Generic[T]):
             else:
                 updates.append(pl.col(col_name))
 
+        # No _id_set upkeep: the `id` positional shadows any `id=` kwarg, so
+        # update() cannot rename a row. update_many() can, and does resync.
         self._df = self._apply_storage_schema(self._df.select(updates), set(kwargs))
 
     def update_many(self, ids: list[ID], **kwargs: Any) -> int:
         """Update multiple rows by ID. Returns count of updated rows."""
+        self._flush()
         if self._df.is_empty():
             return 0
 
@@ -395,24 +450,30 @@ class Table(Generic[T]):
                 updates.append(pl.col(col_name))
 
         self._df = self._apply_storage_schema(self._df.select(updates), set(kwargs))
+        if "id" in kwargs:
+            self._id_set = self._ids_from_df()
         return count
 
     def remove(self, id: ID) -> bool:
         """Remove a row by ID. Returns True if removed, False if not found."""
+        self._flush()
         if self._df.is_empty():
             return False
 
         original_len = len(self._df)
         self._df = self._df.filter(pl.col("id") != id)
+        self._id_set = self._ids_from_df()
         return len(self._df) < original_len
 
     def remove_all(self, ids: list[ID]) -> int:
         """Remove multiple rows by ID. Returns count of removed rows."""
+        self._flush()
         if self._df.is_empty():
             return 0
 
         original_len = len(self._df)
         self._df = self._df.filter(~pl.col("id").is_in(ids))
+        self._id_set = self._ids_from_df()
         return original_len - len(self._df)
 
     def remove_where(self, column: str, op: Operator, value: Any = None) -> int:
@@ -434,11 +495,71 @@ class Table(Generic[T]):
                 prepared[key] = value
         return prepared
 
+    def _validate_rows_for_storage(self, rows: list[dict[str, Any]]) -> None:
+        """Reject rows that _flush() could not materialize, on the offending call.
+
+        A buffered append builds no DataFrame, so the two checks flush would make
+        are run here instead: the scalar cast guard of _validate_storage_cast, and
+        polars' own type reconciliation. The latter is probed only when a column
+        sees a new Python type, which costs nothing on homogeneous rows.
+
+        Tracking state is committed only once every row passes, so a row rejected
+        on its second column cannot leave a sample behind from its first.
+        """
+        types = dict(self._pending_types)
+        samples = dict(self._pending_samples)
+
+        for row in rows:
+            for col_name, value in row.items():
+                if value is None:
+                    continue
+                self._validate_scalar_cast(col_name, value)
+                if types.get(col_name) is not type(value):
+                    self._probe_column_type(col_name, value, samples.get(col_name))
+                    types[col_name] = type(value)
+                    samples[col_name] = value
+
+        self._pending_types = types
+        self._pending_samples = samples
+
+    def _validate_scalar_cast(self, col_name: str, value: Any) -> None:
+        target_dtype = self._storage_schema.get(col_name)
+        if target_dtype is None or not _dtype_is_integer(target_dtype):
+            return
+        if isinstance(value, bool) or not isinstance(value, float):
+            return
+        if math.isnan(value) or not value.is_integer():
+            raise ValueError(
+                f"Column '{col_name}' contains non-integer values and cannot "
+                f"be stored as {target_dtype}"
+            )
+
+    def _probe_column_type(self, col_name: str, value: Any, previous: Any) -> None:
+        """Raise if polars could not reconcile `value` with the column.
+
+        Replays flush's two steps on a one-column, at-most-two-row frame rather
+        than reimplementing polars' supertype rules: pl.DataFrame() covers the
+        conflict against a sample already buffered, pl.concat() the conflict
+        against the dtype already stored in _df.
+        """
+        rows = [] if previous is None else [{col_name: previous}]
+        rows.append({col_name: value})
+        probe = pl.DataFrame(rows, infer_schema_length=None)
+
+        # An empty _df is replaced wholesale by _flush(), schema included, so its
+        # columns must not constrain the probe — a zero-row frame keeps its dtypes.
+        if not self._df.is_empty() and col_name in self._df.columns:
+            pl.concat(
+                [self._df.head(0).select(col_name), probe], how="diagonal_relaxed"
+            )
+
     def set_entity_type(self, entity_type: type[T] | None) -> None:
+        self._flush()
         self._entity_type = entity_type
         self._storage_schema = _storage_schema_from_entity_type(entity_type)
         if self._storage_schema:
             self._df = self._apply_storage_schema(self._df)
+            self._id_set = self._ids_from_df()
 
     def _apply_storage_schema(
         self, df: pl.DataFrame, column_names: set[str] | None = None
@@ -476,6 +597,9 @@ def _storage_schema_from_entity_type(
 
 
 def _validate_storage_cast(df: pl.DataFrame, col_name: str, target_dtype: Any) -> None:
+    """Column-level cast guard. Table._validate_scalar_cast mirrors this rule on
+    single values so buffered appends still raise on the offending call; keep the
+    two in step."""
     source_dtype = df.schema[col_name]
     if not (_dtype_is_integer(target_dtype) and _dtype_is_float(source_dtype)):
         return

--- a/jsonjsdb-py/src/jsonjsdb/writer.py
+++ b/jsonjsdb-py/src/jsonjsdb/writer.py
@@ -306,6 +306,34 @@ def _content_hash(content: str) -> str:
     return "sha256:" + hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
+def _reject_commas_in_string_list(df: pl.DataFrame, col_name: str) -> None:
+    """A comma-separated column cannot represent a value containing a comma.
+
+    Splitting it back on read would silently turn one id into two, so refuse to
+    write it at all rather than corrupt the export.
+    """
+    offending = df.filter(
+        pl.col(col_name)
+        .list.eval(pl.element().str.contains(",", literal=True))
+        .list.any()
+    )
+    if offending.is_empty():
+        return
+
+    sample = offending[col_name][0].to_list()
+    raise ValueError(
+        f"Column '{col_name}' contains a value with a comma ({sample!r}) and "
+        f"cannot be stored: string list columns are written comma-separated"
+    )
+
+
+def validate_df_for_write(df: pl.DataFrame) -> None:
+    """Raise if df cannot be represented on disk, before any file is written."""
+    for col_name, col_type in df.schema.items():
+        if isinstance(col_type, pl.List) and col_type.inner == pl.Utf8:
+            _reject_commas_in_string_list(df, col_name)
+
+
 def _prepare_df_for_write(df: pl.DataFrame) -> pl.DataFrame:
     """Prepare DataFrame for writing for valid JSON output:
 
@@ -320,6 +348,7 @@ def _prepare_df_for_write(df: pl.DataFrame) -> pl.DataFrame:
         col_type = df.schema[col_name]
         if isinstance(col_type, pl.List):
             if col_type.inner == pl.Utf8:  # string lists (e.g. *_ids) -> CSV
+                _reject_commas_in_string_list(df, col_name)
                 transforms.append(
                     pl.col(col_name)
                     .cast(pl.List(pl.Utf8))

--- a/jsonjsdb-py/tests/test_jsonjsdb.py
+++ b/jsonjsdb-py/tests/test_jsonjsdb.py
@@ -2358,3 +2358,548 @@ def test_nan_in_numeric_list_becomes_null(tmp_path: Path):
 
     rows = json.loads((tmp_path / "data.json").read_text())
     assert rows[0]["bbox"] == [6.02, None, 10.5, 47.8]
+
+
+# --- Buffered appends ---
+
+
+def test_buffered_adds_are_materialized_in_a_single_chunk():
+    """N appends on a fresh table must concat once, not once per row."""
+    table: Table[dict] = Table("t")
+    for i in range(500):
+        table.add({"id": f"i{i}", "v": i})
+
+    assert table.count == 500
+    assert table.df.n_chunks() == 1
+
+
+def test_read_after_write_sees_buffered_rows():
+    table: Table[dict] = Table("t")
+    table.add({"id": "a", "v": 1})
+    table.add_all([{"id": "b", "v": 2}, {"id": "c", "v": 3}])
+
+    assert table.count == 3
+    assert not table.is_empty
+    assert table.get("b") == {"id": "b", "v": 2}
+    assert table.exists("c")
+    assert [r["id"] for r in table.all()] == ["a", "b", "c"]
+    assert table.ids_where("v", ">", 1) == ["b", "c"]
+    assert table.get_by("v", 3) == {"id": "c", "v": 3}
+    assert table.get_many(["a", "c"]) == [{"id": "a", "v": 1}, {"id": "c", "v": 3}]
+
+
+def test_buffered_duplicate_id_raises_immediately():
+    table: Table[dict] = Table("t")
+    table.add({"id": "a"})
+
+    with pytest.raises(ValueError, match="already exists"):
+        table.add({"id": "a"})
+    with pytest.raises(ValueError, match="IDs already exist"):
+        table.add_all([{"id": "a"}])
+
+
+def test_insertion_order_preserved_across_flush_boundary():
+    table: Table[dict] = Table("t")
+    table.add({"id": "a"})
+    table.add({"id": "b"})
+    table.get("a")  # forces a flush mid-stream
+    table.add({"id": "c"})
+    table.add_all([{"id": "d"}, {"id": "e"}])
+
+    assert [r["id"] for r in table.all()] == ["a", "b", "c", "d", "e"]
+
+
+def test_mutations_interleaved_with_buffered_adds():
+    table: Table[dict] = Table("t")
+    table.add({"id": "a", "v": 1})
+    table.add({"id": "b", "v": 2})
+
+    assert table.remove("a") is True  # removes a still-buffered row
+    table.add({"id": "c", "v": 3})
+    table.update("b", v=20)
+
+    assert [(r["id"], r["v"]) for r in table.all()] == [("b", 20), ("c", 3)]
+    assert table.count == 2
+
+    table.add({"id": "a", "v": 1})  # id is free again after removal
+    assert table.exists("a")
+
+
+def test_upsert_replaces_a_buffered_row():
+    table: Table[dict] = Table("t")
+    table.add({"id": "a", "v": 1})
+
+    assert table.upsert({"id": "a", "v": 2}) is False
+    assert table.get("a") == {"id": "a", "v": 2}
+    assert table.count == 1
+
+
+def test_get_persistable_df_flushes_pending_rows():
+    table: Table[dict] = Table("t", runtime_fields={"tmp"})
+    table.add({"id": "a", "keep": 1, "tmp": 9})
+
+    persistable = table.get_persistable_df()
+    assert persistable.columns == ["id", "keep"]
+    assert persistable.height == 1
+
+
+def test_save_flushes_buffered_rows_without_a_prior_read(tmp_path: Path):
+    class ItemDB(Jsonjsdb):
+        item: Table[dict]
+
+    db = ItemDB()
+    db.item.add_all([{"id": f"i{i}", "n": i} for i in range(3)])
+    db.save(tmp_path)
+
+    reloaded = ItemDB(tmp_path)
+    assert [r["id"] for r in reloaded.item.all()] == ["i0", "i1", "i2"]
+
+
+def test_typed_integer_field_rejects_non_integral_float_in_add_all():
+    """Eager scalar validation: the offending call raises, not a later read."""
+
+    class Metric(TypedDict):
+        id: str
+        count: Optional[int]
+
+    class MetricDB(Jsonjsdb):
+        metric: Table[Metric]
+
+    db = MetricDB()
+    with pytest.raises(ValueError, match="non-integer values"):
+        db.metric.add_all(
+            [
+                {"id": "row-1", "count": 1},
+                {"id": "row-2", "count": 392.5},  # type: ignore[typeddict-item]
+            ]
+        )
+
+    assert db.metric.count == 0  # the whole batch is rejected, nothing buffered
+    assert not db.metric.exists("row-1")
+
+
+def test_typed_integer_field_accepts_integral_float_and_null():
+    class Metric(TypedDict):
+        id: str
+        count: Optional[int]
+
+    class MetricDB(Jsonjsdb):
+        metric: Table[Metric]
+
+    db = MetricDB()
+    db.metric.add({"id": "row-1", "count": 3.0})  # type: ignore[typeddict-item]
+    db.metric.add({"id": "row-2", "count": None})
+
+    assert db.metric.df.schema["count"] == pl.Int64
+    assert db.metric.get("row-1") == {"id": "row-1", "count": 3}
+    assert db.metric.get("row-2") == {"id": "row-2", "count": None}
+
+
+def test_count_matches_row_count_when_df_has_duplicate_ids():
+    """count must not be derived from the id set: loaded ids need not be unique."""
+    table: Table[dict] = Table("t", df=pl.DataFrame({"id": ["a", "a", "b"]}))
+
+    assert table.count == 3
+    assert len(table.all()) == 3
+
+
+def test_exists_and_get_work_on_a_non_utf8_id_column():
+    table: Table[dict] = Table("t", df=pl.DataFrame({"id": [1, 2], "v": ["x", "y"]}))
+    numeric_id = cast(str, 1)  # ID is str, but a loaded df may hold integer ids
+
+    assert table.exists(numeric_id) is True
+    assert table.get(numeric_id) == {"id": 1, "v": "x"}
+
+
+def test_update_cannot_rename_an_id():
+    """The `id` positional shadows an `id=` kwarg, so update() never renames."""
+    table: Table[dict] = Table("t")
+    table.add({"id": "a", "v": 1})
+
+    with pytest.raises(TypeError, match="multiple values for argument 'id'"):
+        table.update("a", id="b")  # type: ignore[misc]
+
+
+def test_update_many_that_renames_ids_keeps_uniqueness_tracking_in_sync():
+    table: Table[dict] = Table("t")
+    table.add_all([{"id": "a", "v": 1}, {"id": "b", "v": 2}])
+
+    assert table.update_many(["a"], id="z") == 1
+    assert not table.exists("a")
+    assert table.exists("z")
+
+    table.add({"id": "a", "v": 3})  # the old id is free again
+    with pytest.raises(ValueError, match="already exists"):
+        table.add({"id": "z", "v": 4})
+
+
+def test_irreconcilable_row_raises_on_add_and_leaves_the_table_usable():
+    """The buffer must not turn a rejected row into an unreadable table."""
+    table: Table[dict] = Table("t")
+    table.add({"id": "a", "x": 1})
+
+    with pytest.raises(pl.exceptions.SchemaError):
+        table.add({"id": "b", "x": [1, 2]})  # int vs list[int]: no supertype
+
+    assert [r["id"] for r in table.all()] == ["a"]
+    assert table.count == 1
+    assert not table.exists("b")
+    table.add({"id": "b", "x": 2})  # the id was never taken
+
+
+def test_irreconcilable_row_raises_against_an_already_stored_column():
+    table: Table[dict] = Table("t")
+    table.add({"id": "a", "x": 1})
+    table.all()  # flush: x is now an Int64 column of _df
+
+    with pytest.raises(pl.exceptions.SchemaError):
+        table.add({"id": "b", "x": [1, 2]})
+    assert table.count == 1
+
+
+def test_rejected_row_leaves_no_sample_behind_for_later_appends():
+    """A row rejected on its 2nd column must not poison the 1st column's type."""
+
+    class Metric(TypedDict):
+        id: str
+        tags: list[str]
+        count: Optional[int]
+
+    class MetricDB(Jsonjsdb):
+        metric: Table[Metric]
+
+    db = MetricDB()
+    with pytest.raises(ValueError, match="non-integer values"):
+        db.metric.add({"id": "a", "tags": ["x"], "count": 392.5})  # type: ignore[typeddict-item]
+
+    # 'tags' saw a list before the row was rejected; a str must still be accepted
+    db.metric.add({"id": "b", "tags": "x", "count": 1})  # type: ignore[typeddict-item]
+    assert db.metric.count == 1
+
+
+def test_column_type_widening_is_still_accepted():
+    table: Table[dict] = Table("t")
+    table.add_all([{"id": "a", "x": 1}, {"id": "b", "x": 1.5}, {"id": "c", "x": "s"}])
+
+    assert table.df.schema["x"] == pl.String
+    assert [r["x"] for r in table.all()] == ["1", "1.5", "s"]
+
+
+def test_insert_only_upsert_loop_stays_buffered():
+    table: Table[dict] = Table("t")
+    for i in range(500):
+        assert table.upsert({"id": f"i{i}", "v": i}) is True
+
+    assert table.count == 500
+    assert table.df.n_chunks() == 1
+
+
+def test_upsert_updates_a_row_that_is_still_buffered():
+    table: Table[dict] = Table("t")
+    table.add({"id": "a", "v": 1})
+
+    assert table.upsert({"id": "a", "v": 2}) is False
+    assert table.get("a") == {"id": "a", "v": 2}
+    assert table.count == 1
+
+
+def test_upsert_all_appends_new_ids_in_batch_order_deterministically():
+    """Row order reaches save() and its hashes, so it must not depend on a join."""
+    orders = set()
+    for _ in range(20):
+        table: Table[dict] = Table("t")
+        table.add_all(
+            [{"id": "i4", "v": 1}, {"id": "i5", "v": 2}, {"id": "i2", "v": 3}]
+        )
+        table.all()  # flush, so upsert_all replaces against a stored frame
+        table.upsert_all(
+            [{"id": "i2", "v": 7}, {"id": "i3", "v": 99}, {"id": "i1", "v": 98}]
+        )
+        orders.add(tuple(r["id"] for r in table.all()))
+
+    assert orders == {("i4", "i5", "i2", "i3", "i1")}
+
+
+def test_upsert_all_preserves_runtime_fields_on_replaced_rows():
+    table: Table[dict] = Table("t", runtime_fields={"rt"})
+    table.add_all([{"id": "a", "v": 1, "rt": 10}, {"id": "b", "v": 2, "rt": 20}])
+
+    table.upsert_all([{"id": "b", "v": 9}, {"id": "c", "v": 3}])
+
+    assert table.get("b") == {"id": "b", "v": 9, "rt": 20}
+    assert table.get("c") == {"id": "c", "v": 3, "rt": None}
+
+
+# --- Buffering must be invisible: differential test against an eagerly flushed table ---
+
+_DIFF_READS = [
+    ("count", lambda t: t.count),
+    ("is_empty", lambda t: t.is_empty),
+    ("all", lambda t: t.all()),
+    ("shape", lambda t: t.df.shape),
+    ("schema", lambda t: str(t.df.schema)),
+    ("persistable", lambda t: t.get_persistable_df().shape),
+]
+
+
+def _outcome(fn):
+    """Return the value, or the exception type, so both are compared."""
+    try:
+        return ("ok", fn())
+    except Exception as exc:
+        return ("raised", type(exc).__name__)
+
+
+def _random_row(rng, ids):
+    row: dict = {"id": rng.choice(ids)}
+    if rng.random() < 0.85:
+        row["n"] = rng.choice([1, 2, 1.5, None])
+    if rng.random() < 0.5:
+        row["s"] = rng.choice(["a", "b", None])
+    if rng.random() < 0.1:
+        row["n"] = [1, 2]  # irreconcilable with an int column
+    if rng.random() < 0.3:
+        row["extra"] = rng.randint(0, 5)
+    return row
+
+
+def _random_op(rng, ids):
+    """Build the op eagerly: both tables must receive the very same rows."""
+    r = rng.random()
+    if r < 0.30:
+        row = _random_row(rng, ids)
+        return lambda t: t.add(dict(row))
+    if r < 0.42:
+        rows = [_random_row(rng, ids) for _ in range(rng.randint(1, 3))]
+        return lambda t: t.add_all([dict(row) for row in rows])
+    if r < 0.54:
+        row = _random_row(rng, ids)
+        return lambda t: t.upsert(dict(row))
+    if r < 0.62:
+        rows = [_random_row(rng, ids) for _ in range(rng.randint(1, 2))]
+        return lambda t: t.upsert_all([dict(row) for row in rows])
+    if r < 0.70:
+        i, n = rng.choice(ids), rng.randint(0, 9)
+        return lambda t: t.update(i, n=n)
+    if r < 0.76:
+        sample = rng.sample(ids, 2)
+        return lambda t: t.update_many(sample, s="z")
+    if r < 0.82:
+        i = rng.choice(ids)
+        return lambda t: t.remove(i)
+    if r < 0.86:
+        sample = rng.sample(ids, 2)
+        return lambda t: t.remove_all(sample)
+    if r < 0.90:
+        return lambda t: t.remove_where("n", "==", 1)
+    if r < 0.94:
+        i = rng.choice(ids)
+        return lambda t: t.get(i)
+    if r < 0.97:
+        return lambda t: t.where("n", ">", 0)
+    return lambda t: t.ids_where("s", "==", "a")
+
+
+@pytest.mark.parametrize("seed", range(60))
+def test_buffering_is_invisible_on_random_operation_sequences(seed: int):
+    """A buffered table must be indistinguishable from one flushed after every write.
+
+    At most one read runs per step, rotating, and only sometimes: a read that
+    forgets to flush must be the first to touch the table after a write, and
+    writes must be able to pile up so the next op meets a non-empty buffer.
+    """
+    import random
+
+    rng = random.Random(seed)
+    ids = [f"i{k}" for k in range(6)]
+    buffered: Table[dict] = Table("buffered")
+    reference: Table[dict] = Table("reference")
+
+    for step in range(40):
+        op = _random_op(rng, ids)
+        assert _outcome(lambda: op(buffered)) == _outcome(lambda: op(reference))
+        reference._flush()  # the reference never carries a buffer
+
+        if rng.random() < 0.5:  # otherwise let the buffer accumulate
+            name, read = _DIFF_READS[step % len(_DIFF_READS)]
+            got = _outcome(lambda: read(buffered))
+            expected = _outcome(lambda: read(reference))
+            assert got == expected, f"{name} diverged at step {step}"
+
+    assert _outcome(lambda: buffered.df.to_dicts()) == _outcome(
+        lambda: reference.df.to_dicts()
+    )
+
+
+def test_probe_ignores_the_schema_of_an_emptied_table():
+    """_flush() replaces an empty _df wholesale, so its dtypes must not constrain add()."""
+    table: Table[dict] = Table("t")
+    table.add({"id": "a", "n": [1, 2]})
+    assert table.remove("a") is True
+    assert table.is_empty
+    assert table.df.schema["n"] == pl.List(pl.Int64)  # zero rows, dtype retained
+
+    table.add({"id": "b", "n": 2})  # would clash with List(Int64) if _df constrained it
+
+    assert table.get("b") == {"id": "b", "n": 2}
+    assert table.df.schema["n"] == pl.Int64
+
+
+# --- save -> reload -> save must be deterministic, idempotent, buffer-agnostic ---
+
+_SAVE_TIMESTAMP = 1_700_000_000
+
+
+class _ItemDB(Jsonjsdb):
+    item: Table[dict]
+
+
+def _snapshot(path: Path) -> dict[str, str]:
+    """Every written file -> its content hash."""
+    return {
+        str(p.relative_to(path)): file_hash(p)
+        for p in sorted(path.rglob("*"))
+        if p.is_file()
+    }
+
+
+def _saved_snapshot(rows: list[dict], path: Path, *, buffered: bool) -> dict[str, str]:
+    db = _ItemDB()
+    db.item.add_all([dict(r) for r in rows])
+    if not buffered:
+        db.item.all()  # materialize before saving
+    db.save(path, timestamp=_SAVE_TIMESTAMP)
+    return _snapshot(path)
+
+
+_ROUNDTRIP_CASES = [
+    ("scalars", [{"id": "a", "n": 1, "s": "x", "f": 1.5, "b": True}]),
+    ("nulls", [{"id": "a", "n": None, "s": None}, {"id": "b", "n": 2, "s": "y"}]),
+    ("ids_list", [{"id": "a", "tag_ids": ["t1", "t2"]}, {"id": "b", "tag_ids": []}]),
+    ("ids_null", [{"id": "a", "tag_ids": None}]),
+    ("float_list", [{"id": "a", "bbox": [1.5, 2.5]}]),
+    ("int_list", [{"id": "a", "dims": [1, 2]}]),
+    ("empty_string", [{"id": "a", "s": ""}]),
+    ("unicode", [{"id": "a", "s": "héllo → ✓"}]),
+    ("numeric_looking_string", [{"id": "a", "s": "0123"}]),
+]
+
+_roundtrip = pytest.mark.parametrize(
+    "rows", [c[1] for c in _ROUNDTRIP_CASES], ids=[c[0] for c in _ROUNDTRIP_CASES]
+)
+
+
+@_roundtrip
+def test_save_is_deterministic(rows: list[dict], tmp_path: Path):
+    assert _saved_snapshot(rows, tmp_path / "a", buffered=True) == _saved_snapshot(
+        rows, tmp_path / "b", buffered=True
+    )
+
+
+@_roundtrip
+def test_save_does_not_depend_on_whether_rows_were_buffered(
+    rows: list[dict], tmp_path: Path
+):
+    assert _saved_snapshot(rows, tmp_path / "a", buffered=True) == _saved_snapshot(
+        rows, tmp_path / "b", buffered=False
+    )
+
+
+@_roundtrip
+def test_reloading_and_saving_again_rewrites_the_same_files(
+    rows: list[dict], tmp_path: Path
+):
+    """A scan that produced the same data must not churn the exported files."""
+    first = _saved_snapshot(rows, tmp_path / "a", buffered=True)
+
+    reloaded = _ItemDB(tmp_path / "a")
+    reloaded.save(tmp_path / "b", timestamp=_SAVE_TIMESTAMP)
+
+    assert _snapshot(tmp_path / "b") == first
+
+
+@_roundtrip
+def test_reloading_preserves_row_content(rows: list[dict], tmp_path: Path):
+    original = _ItemDB()
+    original.item.add_all([dict(r) for r in rows])
+    expected = original.item.all()
+    original.save(tmp_path, timestamp=_SAVE_TIMESTAMP)
+
+    assert _ItemDB(tmp_path).item.all() == expected
+
+
+def test_saving_an_id_containing_a_comma_raises(tmp_path: Path):
+    """The CSV encoding cannot represent it; refuse rather than split it on read."""
+    db = _ItemDB()
+    db.item.add_all([{"id": "a", "tag_ids": ["x,y", "z"]}])
+
+    with pytest.raises(ValueError, match="tag_ids.*comma"):
+        db.save(tmp_path, timestamp=_SAVE_TIMESTAMP)
+
+
+def test_saving_string_lists_without_commas_is_unaffected(tmp_path: Path):
+    db = _ItemDB()
+    db.item.add_all(
+        [
+            {"id": "a", "tag_ids": ["t1", "t2"]},
+            {"id": "b", "tag_ids": []},
+            {"id": "c", "tag_ids": None},
+        ]
+    )
+    db.save(tmp_path, timestamp=_SAVE_TIMESTAMP)
+
+    reloaded = _ItemDB(tmp_path).item
+    assert reloaded.get("a") == {"id": "a", "tag_ids": ["t1", "t2"]}
+    assert reloaded.get("b") == {"id": "b", "tag_ids": []}
+    assert reloaded.get("c") == {"id": "c", "tag_ids": []}
+
+
+def test_comma_rejection_reports_the_column_and_the_offending_value(tmp_path: Path):
+    from jsonjsdb.writer import write_table_json
+
+    df = pl.DataFrame(
+        {
+            "id": ["r1", "r2"],
+            "tag_ids": pl.Series([["ok"], ["x,y", None]], dtype=pl.List(pl.Utf8)),
+        }
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        write_table_json(df, tmp_path / "data.json")
+
+    message = str(excinfo.value)
+    assert "tag_ids" in message
+    assert "x,y" in message  # the offending row, not the clean one
+    assert not (tmp_path / "data.json").exists()
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="every string list is written comma-separated but only *_ids is split "
+    "back, so a plain list column reloads as a string. Stable and idempotent, but "
+    "only a change to the output format could fix it. Delete this marker if it does.",
+)
+def test_reloading_preserves_a_string_list_column_not_named_ids(tmp_path: Path):
+    db = _ItemDB()
+    db.item.add_all([{"id": "a", "tags": ["p", "q"]}])
+    db.save(tmp_path, timestamp=_SAVE_TIMESTAMP)
+
+    assert _ItemDB(tmp_path).item.get("a") == {"id": "a", "tags": ["p", "q"]}
+
+
+def test_an_unwritable_table_aborts_the_save_before_any_file_is_written(
+    tmp_path: Path,
+):
+    class TwoTableDB(Jsonjsdb):
+        aaa: Table[dict]
+        zzz: Table[dict]
+
+    db = TwoTableDB()
+    db.aaa.add({"id": "a", "v": 1})
+    db.zzz.add({"id": "b", "tag_ids": ["x,y"]})
+    target = tmp_path / "export"
+
+    with pytest.raises(ValueError, match="comma"):
+        db.save(target, timestamp=_SAVE_TIMESTAMP)
+
+    assert not target.exists()  # aaa.json must not survive zzz's rejection

--- a/jsonjsdb-py/uv.lock
+++ b/jsonjsdb-py/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "jsonjsdb"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "openpyxl" },


### PR DESCRIPTION
Every `add()` filtered `_df` for uniqueness and concatenated the whole frame, so inserting n rows cost O(n^2): 10.7s to scan 2000 datasets. Rows are now buffered and materialized in a single concat on the next read or non-append mutation, and uniqueness is checked against an in-memory id set. The same scan takes 0.074s.

Buffering stays invisible. Reads flush first, insertion order is preserved, and a row polars cannot reconcile is still rejected on the offending `add()` rather than on a later, unrelated read: the two checks flush would make are replayed on the row, the second only when a column sees a new Python type. A randomized differential test asserts a buffered table is indistinguishable from one flushed after every write.

Verifying that surfaced two bugs, both predating this change:

- `upsert_all()` appended new ids in join order, which is not deterministic. The same data could save to two different `.json` files, and hashes, from one run to the next.
- `save()` flattens string lists to comma-separated values but accepted values containing a comma, silently splitting one id into two on reload. It now raises, before any file is written.

The output format is unchanged: an identical database saves to identical bytes under 0.9.1 and 0.9.2.