### PR TITLE
add: Table.df setter to replace the whole frame (0.9.3)

### DIFF
--- a/jsonjsdb-py/CHANGELOG.md
+++ b/jsonjsdb-py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.3
+
+add: `Table.df` setter — `table.df = f(table.df)` replaces the whole frame, flushing the append buffer, rebuilding the id index and applying the storage schema
+
 ## 0.9.2
 
 perf: Buffer `Table.add()` / `add_all()` / `upsert()` inserts into a single concat — repeated appends are linear, not quadratic (~140x on a 2000-dataset scan)

--- a/jsonjsdb-py/README.md
+++ b/jsonjsdb-py/README.md
@@ -234,6 +234,24 @@ table.get_persistable_df()        # → DataFrame without _seen
 # On save(), runtime_fields are automatically excluded
 ```
 
+## DataFrame Access
+
+Inserts are buffered and materialized on the next read, so reach the underlying
+Polars DataFrame through `table.df` rather than any internal attribute. Reading it
+flushes pending rows; assigning to it replaces the whole frame, rebuilds the id
+index and applies the entity's storage schema.
+
+```python
+table.df                                        # → DataFrame, buffered rows included
+table.df = table.df.with_columns(...)           # add computed columns
+table.df = table.df.join(other, on="id")        # join metadata in
+table.df = table.df.filter(pl.col("keep"))      # drop rows
+```
+
+Rows still buffered when a frame is assigned are replaced by it, as they would be
+by any whole-frame overwrite. A frame the storage schema rejects raises and leaves
+the table untouched.
+
 ## File Format
 
 - `__table__.json` — Index of tables with metadata

--- a/jsonjsdb-py/pyproject.toml
+++ b/jsonjsdb-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jsonjsdb"
-version = "0.9.2"
+version = "0.9.3"
 description = "Python library for JSONJS database loading"
 authors = [{ name = "datannur" }]
 readme = "README.md"

--- a/jsonjsdb-py/src/jsonjsdb/table.py
+++ b/jsonjsdb-py/src/jsonjsdb/table.py
@@ -116,6 +116,24 @@ class Table(Generic[T]):
         self._flush()
         return self._df
 
+    @df.setter
+    def df(self, value: pl.DataFrame) -> None:
+        """Replace the whole frame, e.g. ``table.df = table.df.with_columns(...)``.
+
+        The getter flushes, so the frame handed to a transform already carries the
+        buffered rows. Assigning back replaces them: any row still buffered at that
+        point is dropped, exactly as it would be by ``_df = value`` without a buffer.
+        The storage schema is applied as it is on construction, so this cannot smuggle
+        a value past the typing that ``add()`` enforces.
+        """
+        # Cast before mutating: an invalid frame must leave the table untouched.
+        new_df = self._apply_storage_schema(value)
+        self._df = new_df
+        self._pending = []
+        self._pending_types = {}
+        self._pending_samples = {}
+        self._id_set = self._ids_from_df()
+
     @property
     def count(self) -> int:
         """Number of rows in the table."""

--- a/jsonjsdb-py/tests/test_jsonjsdb.py
+++ b/jsonjsdb-py/tests/test_jsonjsdb.py
@@ -2690,12 +2690,18 @@ def _random_op(rng, ids):
     if r < 0.86:
         sample = rng.sample(ids, 2)
         return lambda t: t.remove_all(sample)
-    if r < 0.90:
+    if r < 0.88:
         return lambda t: t.remove_where("n", "==", 1)
+    if r < 0.91:  # whole-frame replacement through the public setter
+        i = rng.choice(ids)
+        return lambda t: setattr(t, "df", t.df.filter(pl.col("id") != i))
     if r < 0.94:
+        k = rng.randint(0, 9)
+        return lambda t: setattr(t, "df", t.df.with_columns(extra=pl.lit(k)))
+    if r < 0.96:
         i = rng.choice(ids)
         return lambda t: t.get(i)
-    if r < 0.97:
+    if r < 0.98:
         return lambda t: t.where("n", ">", 0)
     return lambda t: t.ids_where("s", "==", "a")
 
@@ -2903,3 +2909,110 @@ def test_an_unwritable_table_aborts_the_save_before_any_file_is_written(
         db.save(target, timestamp=_SAVE_TIMESTAMP)
 
     assert not target.exists()  # aaa.json must not survive zzz's rejection
+
+
+# --- Whole-frame replacement: table.df = f(table.df) ---
+
+
+def test_df_setter_transform_sees_buffered_rows():
+    """The getter flushes, so f() is handed the rows added just before."""
+    table: Table[dict] = Table("t")
+    table.add({"id": "a", "v": 1})
+    table.add({"id": "b", "v": 2})
+
+    table.df = table.df.with_columns(doubled=pl.col("v") * 2)
+
+    assert table.all() == [
+        {"id": "a", "v": 1, "doubled": 2},
+        {"id": "b", "v": 2, "doubled": 4},
+    ]
+
+
+def test_df_setter_rebuilds_the_id_index():
+    table: Table[dict] = Table("t")
+    table.add_all([{"id": "a"}, {"id": "b"}])
+
+    table.df = table.df.filter(pl.col("id") != "a")
+
+    assert not table.exists("a")
+    assert table.count == 1
+    table.add({"id": "a"})  # the dropped id is free again
+    with pytest.raises(ValueError, match="already exists"):
+        table.add({"id": "b"})  # a surviving id is still taken
+
+
+def test_df_setter_picks_up_ids_introduced_by_the_transform():
+    table: Table[dict] = Table("t")
+    table.add({"id": "a"})
+
+    table.df = pl.concat([table.df, pl.DataFrame({"id": ["grafted"]})])
+
+    assert table.exists("grafted")
+    with pytest.raises(ValueError, match="already exists"):
+        table.add({"id": "grafted"})
+
+
+def test_df_setter_clears_the_buffered_type_samples():
+    """A sample left over from a dropped column would falsely reject a later add."""
+    table: Table[dict] = Table("t")
+    table.add({"id": "a", "x": 1})  # 'x' sampled as int, still buffered
+
+    table.df = pl.DataFrame({"id": ["z"]})  # 'x' no longer exists anywhere
+
+    table.add({"id": "b", "x": [1, 2]})  # must not clash with the stale int sample
+    assert table.get("b") == {"id": "b", "x": [1, 2]}
+
+
+def test_df_setter_replaces_rows_that_were_still_buffered():
+    table: Table[dict] = Table("t")
+    table.add({"id": "buffered"})
+
+    table.df = pl.DataFrame({"id": ["fresh"]})
+
+    assert [r["id"] for r in table.all()] == ["fresh"]
+    assert table.count == 1
+
+
+def test_df_setter_applies_the_storage_schema():
+    class Metric(TypedDict):
+        id: str
+        count: Optional[int]
+
+    class MetricDB(Jsonjsdb):
+        metric: Table[Metric]
+
+    db = MetricDB()
+    db.metric.df = pl.DataFrame({"id": ["a"], "count": [3.0]})
+
+    assert db.metric.df.schema["count"] == pl.Int64
+    assert db.metric.get("a") == {"id": "a", "count": 3}
+
+
+def test_df_setter_rejects_an_unstorable_frame_and_leaves_the_table_intact():
+    class Metric(TypedDict):
+        id: str
+        count: Optional[int]
+
+    class MetricDB(Jsonjsdb):
+        metric: Table[Metric]
+
+    db = MetricDB()
+    db.metric.add({"id": "a", "count": 1})
+    before = db.metric.all()
+
+    with pytest.raises(ValueError, match="non-integer values"):
+        db.metric.df = pl.DataFrame({"id": ["b"], "count": [2.5]})
+
+    assert db.metric.all() == before
+
+
+def test_df_setter_output_is_saved(tmp_path: Path):
+    db = _ItemDB()
+    db.item.add_all([{"id": "a", "v": 1}, {"id": "b", "v": 2}])
+    db.item.df = db.item.df.with_columns(v=pl.col("v") * 10)
+    db.save(tmp_path, timestamp=_SAVE_TIMESTAMP)
+
+    assert _ItemDB(tmp_path).item.all() == [
+        {"id": "a", "v": 10},
+        {"id": "b", "v": 20},
+    ]

--- a/jsonjsdb-py/uv.lock
+++ b/jsonjsdb-py/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "jsonjsdb"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "openpyxl" },


### PR DESCRIPTION
Buffered inserts made `table._df` unusable from outside: reading it missed rows still in `_pending`, and assigning to it bypassed the flush and left `_id_set` stale. The getter already flushed, but there was no public way to write the frame back, so whole-frame transforms — computed columns, derived ids, metadata joins — had no supported API.

`table.df = f(table.df)` is now that API. The getter flushes, so `f` sees the buffered rows; the setter replaces the frame, drops the buffer and its type samples, and rebuilds the id index.

The setter also applies the storage schema, as construction and `set_entity_type()` do. Without it, assigning a frame could persist a float into a field declared `int`, which `add()` rejects. The frame is cast before any state is mutated, so a frame the schema refuses raises and leaves the table untouched.