### PR TITLE
fix: replace the full relation-table scan in `hasRelation()` with an …

### DIFF
--- a/jsonjsdb/CHANGELOG.md
+++ b/jsonjsdb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsonjsdb
 
+## 0.12.3 (2026-07-12)
+
+- fix: replace the full relation-table scan in `hasRelation()` with an index lookup, making repeated `addRelation()`/`addRelations()` calls linear instead of quadratic
+
 ## 0.12.2 (2026-06-04)
 
 - add: addForeignKey() method to add foreign key indexes to existing objects

--- a/jsonjsdb/package.json
+++ b/jsonjsdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonjsdb",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Jsonjsdb database",
   "type": "module",
   "license": "MIT",

--- a/jsonjsdb/src/Jsonjsdb.ts
+++ b/jsonjsdb/src/Jsonjsdb.ts
@@ -784,19 +784,14 @@ export default class Jsonjsdb<
       }
     }
 
-    const relationTableName = this.relationTableName(table, relatedTable)
-    const relationTable = (this.tables as Record<string, DatabaseRow[]>)[
-      relationTableName
-    ]
-    if (!Array.isArray(relationTable)) return false
-
-    const tableKey = table + this.idSuffix
-    const relatedKey = relatedTable + this.idSuffix
-    return relationTable.some(
-      row =>
-        this.sameId(row[tableKey], id) &&
-        this.sameId(row[relatedKey], relatedId),
-    )
+    const positions =
+      this.metadata.index[table]?.[relatedTable + this.idSuffix]?.[relatedId]
+    if (positions === undefined) return false
+    const sourcePosition = this.metadata.index[table]?.id?.[id]
+    if (typeof sourcePosition !== 'number') return false
+    return Array.isArray(positions)
+      ? positions.includes(sourcePosition)
+      : positions === sourcePosition
   }
 
   private planRelations(

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       }
     },
     "jsonjsdb": {
-      "version": "0.12.2",
+      "version": "0.12.3",
       "license": "MIT",
       "devDependencies": {
         "@vitest/browser": "^4.1.8",


### PR DESCRIPTION
…index lookup, making repeated `addRelation()`/`addRelations()` calls linear instead of quadratic