### PR TITLE
fix: scan the smaller of the two index sides in `hasRelation()` and s…

### DIFF
--- a/jsonjsdb/CHANGELOG.md
+++ b/jsonjsdb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsonjsdb
 
+## 0.12.4 (2026-07-12)
+
+- fix: scan the smaller of the two index sides in `hasRelation()` and skip the redundant duplicate check when appending relation positions to the index, removing the remaining quadratic behavior of repeated relation inserts
+
 ## 0.12.3 (2026-07-12)
 
 - fix: replace the full relation-table scan in `hasRelation()` with an index lookup, making repeated `addRelation()`/`addRelations()` calls linear instead of quadratic

--- a/jsonjsdb/package.json
+++ b/jsonjsdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonjsdb",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Jsonjsdb database",
   "type": "module",
   "license": "MIT",

--- a/jsonjsdb/src/Jsonjsdb.ts
+++ b/jsonjsdb/src/Jsonjsdb.ts
@@ -669,6 +669,25 @@ export default class Jsonjsdb<
     if (bucket !== position) index[key] = [bucket, position]
   }
 
+  private pushPositionToIndex(
+    index: IndexRecord,
+    key: string | number,
+    position: number,
+  ): void {
+    if (!(key in index)) {
+      index[key] = position
+      return
+    }
+
+    const bucket = index[key]
+    if (Array.isArray(bucket)) {
+      bucket.push(position)
+      return
+    }
+
+    index[key] = [bucket, position]
+  }
+
   private relationFieldToTable(relationField: string): string {
     return this.resolveRelationField(relationField).toTable
   }
@@ -732,12 +751,14 @@ export default class Jsonjsdb<
       [table + this.idSuffix]: id,
       [relatedTable + this.idSuffix]: relatedId,
     })
-    this.addPositionToIndex(
+    // hasRelation() returned false above, so the pair is absent from both
+    // index sides: push without the linear duplicate check
+    this.pushPositionToIndex(
       this.ensureIndex(table, relatedTable + this.idSuffix),
       relatedId,
       sourcePosition,
     )
-    this.addPositionToIndex(
+    this.pushPositionToIndex(
       this.ensureIndex(relatedTable, table + this.idSuffix),
       id,
       relatedPosition,
@@ -784,14 +805,27 @@ export default class Jsonjsdb<
       }
     }
 
-    const positions =
-      this.metadata.index[table]?.[relatedTable + this.idSuffix]?.[relatedId]
-    if (positions === undefined) return false
-    const sourcePosition = this.metadata.index[table]?.id?.[id]
+    const index = this.metadata.index
+    const sourceBucket =
+      index[table]?.[relatedTable + this.idSuffix]?.[relatedId]
+    if (sourceBucket === undefined) return false
+    const relatedBucket = index[relatedTable]?.[table + this.idSuffix]?.[id]
+    if (relatedBucket === undefined) return false
+    const sourcePosition = index[table]?.id?.[id]
+    const relatedPosition = index[relatedTable]?.id?.[relatedId]
     if (typeof sourcePosition !== 'number') return false
-    return Array.isArray(positions)
-      ? positions.includes(sourcePosition)
-      : positions === sourcePosition
+    if (typeof relatedPosition !== 'number') return false
+
+    // both index sides hold the same pairs: scan the smaller bucket
+    const sourceSize = Array.isArray(sourceBucket) ? sourceBucket.length : 1
+    const relatedSize = Array.isArray(relatedBucket) ? relatedBucket.length : 1
+    const [bucket, position] =
+      sourceSize <= relatedSize
+        ? [sourceBucket, sourcePosition]
+        : [relatedBucket, relatedPosition]
+    return Array.isArray(bucket)
+      ? bucket.includes(position)
+      : bucket === position
   }
 
   private planRelations(

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       }
     },
     "jsonjsdb": {
-      "version": "0.12.3",
+      "version": "0.12.4",
       "license": "MIT",
       "devDependencies": {
         "@vitest/browser": "^4.1.8",


### PR DESCRIPTION
…kip the redundant duplicate check when appending relation positions to the index, removing the remaining quadratic behavior of repeated relation inserts