### PR TITLE
fix: publish TypeScript declarations at the package paths declared in…

### DIFF
--- a/jsonjsdb/CHANGELOG.md
+++ b/jsonjsdb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # jsonjsdb
 
+## 0.12.5 (2026-07-12)
+
+- fix: publish TypeScript declarations at the package paths declared in `package.json` again, using a dedicated `tsconfig.build.json` so the inferred `rootDir` no longer nests them under `dist/src/` (regression introduced by the `vite-plugin-dts` 5.0.2 update, affecting 0.12.3 and 0.12.4)
+
 ## 0.12.4 (2026-07-12)
 
 - fix: scan the smaller of the two index sides in `hasRelation()` and skip the redundant duplicate check when appending relation positions to the index, removing the remaining quadratic behavior of repeated relation inserts

--- a/jsonjsdb/package.json
+++ b/jsonjsdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonjsdb",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Jsonjsdb database",
   "type": "module",
   "license": "MIT",
@@ -35,6 +35,7 @@
   "typings": "dist/Jsonjsdb.d.ts",
   "scripts": {
     "build": "vite build",
+    "postbuild": "node -e \"const t=require('./package.json').types;if(!require('fs').existsSync(t)){console.error('declared types file missing from build output: '+t);process.exit(1)}\"",
     "dev": "vitest",
     "test": "vitest run",
     "test:ui": "vitest --ui",

--- a/jsonjsdb/tsconfig.build.json
+++ b/jsonjsdb/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/jsonjsdb/vite.config.ts
+++ b/jsonjsdb/vite.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
     },
     silent: true,
   },
-  plugins: [dts({ entryRoot: 'src', include: ['src'] })],
+  // the dedicated build tsconfig sets an explicit rootDir so declarations
+  // land at dist/*.d.ts, where package.json points (checked by postbuild)
+  plugins: [dts({ tsconfigPath: 'tsconfig.build.json' })],
   build: {
     minify: 'terser',
     sourcemap: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       }
     },
     "jsonjsdb": {
-      "version": "0.12.4",
+      "version": "0.12.5",
       "license": "MIT",
       "devDependencies": {
         "@vitest/browser": "^4.1.8",


### PR DESCRIPTION
… `package.json` again, using a dedicated `tsconfig.build.json`, and fail the build when the declared types file is missing (0.12.5)

The vite-plugin-dts 5.0.2 update (#122) broke the interplay between the plugin `include` option and its entry-root inference: declarations landed under `dist/src/` while `package.json` points at `dist/Jsonjsdb.d.ts`, so jsonjsdb 0.12.3 and 0.12.4 resolve as untyped in consuming projects. A dedicated `tsconfig.build.json` with an explicit `rootDir` makes the output layout deterministic, and a `postbuild` check now fails CI and release builds if the declared types file is ever missing again.