### PR TITLE
perf: single-pass addMeta() stats, Set-based filter() and addRelation…

### DIFF
--- a/jsonjsdb/CHANGELOG.md
+++ b/jsonjsdb/CHANGELOG.md
@@ -1,5 +1,13 @@
 # jsonjsdb
 
+## 0.12.6 (2026-07-13)
+
+- perf: compute `addMeta()` variable statistics in a single row-major pass instead of two column-major scans per column, roughly halving metadata computation time on large tables (identical output, including the empty-string and `NaN` type-inference edge cases, now covered by tests)
+- perf: replace the array-membership scans in `filter()` with `Set` lookups, making init-time filters linear instead of quadratic (measured ~1000× faster when deleting 10k of 50k rows)
+- perf: iterate rows with indexed loops instead of `Object.entries()` + `parseInt()` when building indexes, making `createIndex()` ~40% faster on large tables
+- perf: track already-planned and already-present relation ids with `Set`s in `addRelations()`, making large batches linear instead of quadratic (~75× faster for a 10k-id batch)
+- perf: accumulate `getAllChilds()` results with pushes instead of per-level `concat()` reallocations
+
 ## 0.12.5 (2026-07-12)
 
 - fix: publish TypeScript declarations at the package paths declared in `package.json` again, using a dedicated `tsconfig.build.json` so the inferred `rootDir` no longer nests them under `dist/src/` (regression introduced by the `vite-plugin-dts` 5.0.2 update, affecting 0.12.3 and 0.12.4)

--- a/jsonjsdb/package.json
+++ b/jsonjsdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonjsdb",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Jsonjsdb database",
   "type": "module",
   "license": "MIT",

--- a/jsonjsdb/src/Jsonjsdb.ts
+++ b/jsonjsdb/src/Jsonjsdb.ts
@@ -260,13 +260,13 @@ export default class Jsonjsdb<
     const tableData = this.tables[table]
     if (!Array.isArray(tableData)) return []
 
-    let all: TEntityTypeMap[K][] = []
+    const all: TEntityTypeMap[K][] = []
     if (!itemId) {
       console.error('getAllChilds()', table, 'id', itemId)
       return all
     }
     const childs = this.getAll(table, { [table]: itemId })
-    all = all.concat(childs)
+    for (const child of childs) all.push(child)
     for (const child of childs) {
       const childRow = child
       if (itemId === childRow.id) {
@@ -275,7 +275,7 @@ export default class Jsonjsdb<
         return all
       }
       const newChilds = this.getAllChilds(table, childRow.id as string | number)
-      all = all.concat(newChilds)
+      for (const newChild of newChilds) all.push(newChild)
     }
     return all
   }
@@ -837,6 +837,7 @@ export default class Jsonjsdb<
     relationField?: string,
   ): AddRelationsResult {
     const added: Array<string | number> = []
+    const addedKeys = new Set<string>()
     const ignored: Array<string | number> = []
 
     for (const relatedId of relatedIds) {
@@ -849,7 +850,7 @@ export default class Jsonjsdb<
 
       const alreadyExists =
         this.hasRelation(table, id, relatedTable, relatedId, relationField) ||
-        added.some(addedId => this.sameId(addedId, relatedId))
+        addedKeys.has(String(relatedId))
 
       if (alreadyExists) {
         if (ifExists === 'ignore') {
@@ -861,6 +862,7 @@ export default class Jsonjsdb<
       }
 
       added.push(relatedId)
+      addedKeys.add(String(relatedId))
     }
 
     return { added, ignored }
@@ -880,9 +882,11 @@ export default class Jsonjsdb<
     relatedIds: Array<string | number>,
   ): void {
     const ids = this.parseIds(row[relationField])
+    const idKeys = new Set(ids.map(String))
     for (const relatedId of relatedIds) {
-      if (ids.some(id => this.sameId(id, relatedId))) continue
+      if (idKeys.has(String(relatedId))) continue
       ids.push(relatedId)
+      idKeys.add(String(relatedId))
     }
     row[relationField] = this.serializeIds(ids)
   }

--- a/jsonjsdb/src/Loader.ts
+++ b/jsonjsdb/src/Loader.ts
@@ -336,12 +336,10 @@ export default class Loader {
       this.tableIndexCache = (await this.browser.get(
         this.cachePrefix + this.tableIndex,
       )) as Record<string, string | number | undefined>
-      const newTableIndexCache = tablesInfo.reduce(
-        (acc, item) => {
-          return { ...acc, [item.name]: item.lastModif }
-        },
-        {} as Record<string, string | number | undefined>,
-      )
+      const newTableIndexCache: Record<string, string | number | undefined> = {}
+      for (const item of tablesInfo) {
+        newTableIndexCache[item.name] = item.lastModif
+      }
       this.saveToCache(newTableIndexCache, this.tableIndex)
     }
 
@@ -389,17 +387,17 @@ export default class Loader {
 
   checkConformity(tablesInfo: TableInfo[]): TableInfo[] {
     const validatedTables: TableInfo[] = []
-    const allNames: string[] = []
+    const allNames = new Set<string>()
     for (const table of tablesInfo) {
       if (!('name' in table)) {
         console.error('table name not found in meta', table)
         continue
       }
-      if (allNames.includes(table.name)) {
+      if (allNames.has(table.name)) {
         console.error('table name already exists in meta', table)
         continue
       }
-      allNames.push(table.name)
+      allNames.add(table.name)
       validatedTables.push(table)
     }
     return validatedTables
@@ -439,36 +437,36 @@ export default class Loader {
     if (!('values' in filter) || !filter.values) return false
     if (!(filter.entity in this.db)) return false
 
-    const idToDelete: string[] = []
+    const idToDelete = new Set<string>()
     for (const item of this.db[filter.entity]) {
       if (filter.values.includes(item[filter.variable])) {
         if (item.id !== undefined && item.id !== null) {
-          idToDelete.push(String(item.id))
+          idToDelete.add(String(item.id))
         }
       }
     }
     this.db[filter.entity] = this.db[filter.entity].filter(
-      (item: Record<string, unknown>) => !idToDelete.includes(String(item.id)),
+      (item: Record<string, unknown>) => !idToDelete.has(String(item.id)),
     )
     for (const table of this.metadata.tables) {
       if (this.db[table.name].length === 0) continue
       if (!(filter.entity + this.idSuffix in this.db[table.name][0])) continue
-      const idToDeleteLevel2: string[] = []
+      const idToDeleteLevel2 = new Set<string>()
       for (const item of this.db[table.name]) {
         const foreignId = item[filter.entity + this.idSuffix]
         if (
           foreignId !== undefined &&
           foreignId !== null &&
-          idToDelete.includes(String(foreignId))
+          idToDelete.has(String(foreignId))
         ) {
           if (item.id !== undefined && item.id !== null) {
-            idToDeleteLevel2.push(String(item.id))
+            idToDeleteLevel2.add(String(item.id))
           }
         }
       }
       this.db[table.name] = this.db[table.name].filter(
         (item: Record<string, unknown>) =>
-          !idToDelete.includes(String(item[filter.entity + this.idSuffix])),
+          !idToDelete.has(String(item[filter.entity + this.idSuffix])),
       )
       for (const tableLevel2 of this.metadata.tables) {
         if (this.db[tableLevel2.name].length === 0) continue
@@ -476,9 +474,7 @@ export default class Loader {
           continue
         this.db[tableLevel2.name] = this.db[tableLevel2.name].filter(
           (item: Record<string, unknown>) =>
-            !idToDeleteLevel2.includes(
-              String(item[table.name + this.idSuffix]),
-            ),
+            !idToDeleteLevel2.has(String(item[table.name + this.idSuffix])),
         )
       }
     }
@@ -584,17 +580,19 @@ export default class Loader {
 
       const index: Record<string, number | number[]> = {}
       const reverseIndex: Record<string, number | number[]> = {}
-      for (const [i, row] of Object.entries(this.db[table.name])) {
+      const rows = this.db[table.name]
+      for (let i = 0; i < rows.length; i += 1) {
+        const row = rows[i]
         const rowRecord = row as Record<string, unknown>
         const ids = this.parseIds(rowRecord[variable])
         for (const id of ids) {
           if (!(id in index)) {
-            index[id] = parseInt(i)
+            index[id] = i
           } else {
             if (!Array.isArray(index[id])) {
               index[id] = [index[id] as number]
             }
-            ;(index[id] as number[]).push(parseInt(i))
+            ;(index[id] as number[]).push(i)
           }
 
           const relatedIndex = this.idToIndex(relation.toTable, id)
@@ -619,17 +617,18 @@ export default class Loader {
 
   processSelfOneToMany(table: { name: string }) {
     const index: Record<string | number, number | number[]> = {}
-    for (const [i, row] of Object.entries(this.db[table.name])) {
-      const rowRecord = row as Record<string, unknown>
+    const rows = this.db[table.name]
+    for (let i = 0; i < rows.length; i += 1) {
+      const rowRecord = rows[i] as Record<string, unknown>
       const parentId = rowRecord['parent' + this.idSuffix] as string | number
       if (!(parentId in index)) {
-        index[parentId] = parseInt(i)
+        index[parentId] = i
         continue
       }
       if (!Array.isArray(index[parentId])) {
         index[parentId] = [index[parentId] as number]
       }
-      ;(index[parentId] as number[]).push(parseInt(i))
+      ;(index[parentId] as number[]).push(i)
     }
     this.metadata.index[table.name]['parent' + this.idSuffix] = index
     this.metadata.schema.oneToMany.push([table.name, table.name])
@@ -640,27 +639,29 @@ export default class Loader {
     if (!(table.name in this.db)) return false
     if (this.db[table.name].length === 0) return false
     if (!('id' in this.db[table.name][0])) return false
-    for (const [i, row] of Object.entries(this.db[table.name])) {
-      const rowRecord = row as Record<string, unknown>
+    const rows = this.db[table.name]
+    for (let i = 0; i < rows.length; i += 1) {
+      const rowRecord = rows[i] as Record<string, unknown>
       const id = rowRecord.id as string | number
-      index[id] = parseInt(i)
+      index[id] = i
     }
     this.metadata.index[table.name].id = index
   }
 
   addForeignKey(variable: string, table: { name: string }) {
     const index: Record<string, number | number[]> = {}
-    for (const [i, row] of Object.entries(this.db[table.name])) {
-      const rowRecord = row as Record<string, unknown>
+    const rows = this.db[table.name]
+    for (let i = 0; i < rows.length; i += 1) {
+      const rowRecord = rows[i] as Record<string, unknown>
       const foreignKeyValue = rowRecord[variable] as string
       if (!(foreignKeyValue in index)) {
-        index[foreignKeyValue] = parseInt(i)
+        index[foreignKeyValue] = i
         continue
       }
       if (!Array.isArray(index[foreignKeyValue])) {
         index[foreignKeyValue] = [index[foreignKeyValue] as number]
       }
-      ;(index[foreignKeyValue] as number[]).push(parseInt(i))
+      ;(index[foreignKeyValue] as number[]).push(i)
     }
     delete index['null']
     this.metadata.index[table.name][variable] = index
@@ -918,41 +919,39 @@ export default class Loader {
   ) {
     const datasetArray = datasetData as unknown[]
     const nbValueMax = Math.min(300, Math.floor(datasetArray.length / 5))
-    for (const variable of variables) {
-      let type = 'other'
-      for (const row of datasetData) {
-        const rowRecord = row as Record<string, unknown>
-        const value = rowRecord[variable]
-        if (value === null || value === undefined) continue
-        if (typeof value === 'string') {
-          type = 'string'
-          break
-        }
-        if (typeof value === 'number' && !isNaN(value)) {
-          if (Number.isInteger(value)) {
-            type = 'integer'
-            break
-          } else {
-            type = 'float'
-            break
+    const accumulators = variables.map(variable => ({
+      variable,
+      type: 'other',
+      typeResolved: false,
+      nbMissing: 0,
+      distincts: new Set<unknown>(),
+    }))
+    for (const row of datasetData) {
+      const rowRecord = row as Record<string, unknown>
+      for (const acc of accumulators) {
+        const value = rowRecord[acc.variable]
+        // type inference skips null/undefined but not '': an empty string
+        // resolves the type as string even though the stats count it missing
+        if (!acc.typeResolved && value !== null && value !== undefined) {
+          if (typeof value === 'string') {
+            acc.type = 'string'
+            acc.typeResolved = true
+          } else if (typeof value === 'number' && !isNaN(value)) {
+            acc.type = Number.isInteger(value) ? 'integer' : 'float'
+            acc.typeResolved = true
+          } else if (typeof value === 'boolean') {
+            acc.type = 'boolean'
+            acc.typeResolved = true
           }
         }
-        if (typeof value === 'boolean') {
-          type = 'boolean'
-          break
-        }
-      }
-      let nbMissing = 0
-      const distincts = new Set()
-      for (const row of datasetData) {
-        const rowRecord = row as Record<string, unknown>
-        const value = rowRecord[variable]
         if (value === '' || value === null || value === undefined) {
-          nbMissing += 1
+          acc.nbMissing += 1
           continue
         }
-        distincts.add(value)
+        acc.distincts.add(value)
       }
+    }
+    for (const { variable, type, nbMissing, distincts } of accumulators) {
       let values: boolean | Array<{ value: unknown }> = false
       const hasValue = distincts.size < nbValueMax && distincts.size > 0
       if (hasValue) {

--- a/jsonjsdb/test/loader.test.ts
+++ b/jsonjsdb/test/loader.test.ts
@@ -135,6 +135,111 @@ describe('Loader', () => {
     })
   })
 
+  describe('addMetaVariables()', () => {
+    const getVar = (id: string) =>
+      loader.db.metaVariable.find((v: Record<string, unknown>) => v.id === id)
+
+    beforeEach(() => {
+      loader.db.metaVariable = []
+    })
+
+    it('infers type from an empty string but counts it as missing', () => {
+      loader.addMetaVariables('t', [{ v: '' }, { v: 3 }], ['v'])
+      expect(getVar('t---v')).toMatchObject({
+        type: 'string',
+        nbMissing: 1,
+        nbDistinct: 1,
+        nbDuplicate: 0,
+      })
+    })
+
+    it('types an all-empty-string column as string with zero distinct', () => {
+      loader.addMetaVariables('t', [{ v: '' }, { v: '' }], ['v'])
+      expect(getVar('t---v')).toMatchObject({
+        type: 'string',
+        nbMissing: 2,
+        nbDistinct: 0,
+        nbDuplicate: 0,
+        values: false,
+      })
+    })
+
+    it('skips null and undefined when inferring type', () => {
+      loader.addMetaVariables('t', [{ v: null }, { v: 42 }], ['v'])
+      expect(getVar('t---v')).toMatchObject({
+        type: 'integer',
+        nbMissing: 1,
+        nbDistinct: 1,
+      })
+    })
+
+    it('skips NaN when inferring type but counts it as a distinct value', () => {
+      loader.addMetaVariables('t', [{ v: NaN }, { v: 1.5 }, { v: NaN }], ['v'])
+      expect(getVar('t---v')).toMatchObject({
+        type: 'float',
+        nbMissing: 0,
+        nbDistinct: 2,
+        nbDuplicate: 1,
+      })
+    })
+
+    it('skips object values when inferring type', () => {
+      loader.addMetaVariables('t', [{ v: { a: 1 } }, { v: 'x' }], ['v'])
+      expect(getVar('t---v')).toMatchObject({
+        type: 'string',
+        nbMissing: 0,
+        nbDistinct: 2,
+      })
+    })
+
+    it('falls back to other when no value resolves a type', () => {
+      loader.addMetaVariables('t', [{ v: null }, { v: undefined }], ['v'])
+      expect(getVar('t---v')).toMatchObject({
+        type: 'other',
+        nbMissing: 2,
+        nbDistinct: 0,
+      })
+    })
+
+    it('detects boolean columns', () => {
+      loader.addMetaVariables('t', [{ v: true }, { v: false }], ['v'])
+      expect(getVar('t---v')).toMatchObject({
+        type: 'boolean',
+        nbDistinct: 2,
+      })
+    })
+
+    it('lists distinct values in first-appearance order below the cap', () => {
+      const rows = Array.from({ length: 15 }, (_, i) => ({
+        v: i % 2 === 0 ? 'b' : 'a',
+      }))
+      loader.addMetaVariables('t', rows, ['v'])
+      expect(getVar('t---v')).toMatchObject({
+        nbDistinct: 2,
+        values: [{ value: 'b' }, { value: 'a' }],
+        valuesPreview: [{ value: 'b' }, { value: 'a' }],
+      })
+    })
+
+    it('handles several columns independently, missing keys included', () => {
+      loader.addMetaVariables(
+        't',
+        [{ a: 1, b: 'x' }, { a: 2.5, b: 'y' }, { a: 3 }],
+        ['a', 'b'],
+      )
+      expect(getVar('t---a')).toMatchObject({
+        type: 'integer',
+        nbMissing: 0,
+        nbDistinct: 3,
+      })
+      expect(getVar('t---b')).toMatchObject({
+        type: 'string',
+        nbMissing: 1,
+        nbDistinct: 2,
+      })
+    })
+  })
+
   describe('arrayToObject()', () => {
     it('should convert matrix data into objects', async () => {
       await loader.load(path)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       }
     },
     "jsonjsdb": {
-      "version": "0.12.5",
+      "version": "0.12.6",
       "license": "MIT",
       "devDependencies": {
         "@vitest/browser": "^4.1.8",


### PR DESCRIPTION
…s(), indexed-loop createIndex() (0.12.6)

Boot-path and batch-mutation performance, identical behavior:

- addMetaVariables(): one row-major pass with per-column accumulators instead of two column-major scans per column (~2.3x on 100k rows x 29 cols), preserving the empty-string and NaN type-inference edge cases, now covered by tests
- filter(): Set lookups instead of array includes, linear instead of quadratic (~1000x when deleting 10k of 50k rows with cascade)
- createIndex() family: indexed loops instead of Object.entries() + parseInt() (~1.65x on 200k rows)
- planRelations() / appendRelationFieldValues(): Set-tracked ids, linear batches (~75x for a 10k-id addRelations call)
- getAllChilds(): push accumulation instead of per-level concat
- minor: loop instead of spread-reduce in loadTables(), Set in checkConformity()