### PR TITLE
feat(py): add save(evolution_exclude) to skip tables from evolution tracking (0.9.4)

### DIFF
--- a/jsonjsdb-py/CHANGELOG.md
+++ b/jsonjsdb-py/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.4
+
+add: `save(evolution_exclude={...})` — exclude tables from evolution tracking entirely (no add/update/delete entries) while still exporting them normally; defaults to no exclusions, so existing behaviour is unchanged
+
 ## 0.9.3
 
 add: `Table.df` setter — `table.df = f(table.df)` replaces the whole frame, flushing the append buffer, rebuilding the id index and applying the storage schema

--- a/jsonjsdb-py/pyproject.toml
+++ b/jsonjsdb-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jsonjsdb"
-version = "0.9.3"
+version = "0.9.4"
 description = "Python library for JSONJS database loading"
 authors = [{ name = "datannur" }]
 readme = "README.md"

--- a/jsonjsdb-py/src/jsonjsdb/database.py
+++ b/jsonjsdb-py/src/jsonjsdb/database.py
@@ -121,6 +121,7 @@ class Jsonjsdb:
         timestamp: int | None = None,
         write_js: bool = True,
         parent_relations: dict[str, str] | None = None,
+        evolution_exclude: set[str] | None = None,
     ) -> None:
         """Save all tables to disk with optional evolution tracking.
 
@@ -135,6 +136,10 @@ class Jsonjsdb:
             write_js: If True, write both .json and .json.js (default: True)
             parent_relations: Child->parent table mapping for cascade filtering
                 Example: {"variable": "dataset", "freq": "variable"}
+            evolution_exclude: Table names to exclude entirely from evolution
+                tracking. Excluded tables are still exported normally (json /
+                json.js), but never produce add/update/delete evolution entries.
+                Example: {"frequency"}
         """
         save_path = Path(path) if path else self._path
 
@@ -173,10 +178,18 @@ class Jsonjsdb:
             def track_table_evolution(data_changed: bool) -> None:
                 if not track_evolution or not data_changed:
                     return
+                if evolution_exclude and name in evolution_exclude:
+                    # Skip the disk read of the old table for excluded tables.
+                    return
 
                 old_df = self._get_old_table(save_path, name, same_path)
                 entries = compare_datasets(
-                    old_df, persistable_df, ts, name, parent_relations
+                    old_df,
+                    persistable_df,
+                    ts,
+                    name,
+                    parent_relations,
+                    evolution_exclude,
                 )
                 new_entries.extend(entries)
 

--- a/jsonjsdb-py/src/jsonjsdb/evolution.py
+++ b/jsonjsdb-py/src/jsonjsdb/evolution.py
@@ -164,6 +164,7 @@ def compare_datasets(
     timestamp: int,
     entity: str,
     parent_relations: dict[str, str] | None = None,
+    exclude: set[str] | None = None,
 ) -> list[EvolutionEntry]:
     """Compare two datasets and return list of evolution entries.
 
@@ -173,6 +174,7 @@ def compare_datasets(
         timestamp: Unix timestamp in seconds
         entity: Table/entity name
         parent_relations: Mapping of child_table -> parent_table for cascade filtering
+        exclude: Table/entity names to skip entirely (no add/update/delete entries)
 
     Returns:
         List of EvolutionEntry objects describing the changes
@@ -180,6 +182,9 @@ def compare_datasets(
     entries: list[EvolutionEntry] = []
 
     if entity.startswith("__"):
+        return entries
+
+    if exclude and entity in exclude:
         return entries
 
     # Skip tracking for initial creation (no previous data)

--- a/jsonjsdb-py/tests/test_evolution.py
+++ b/jsonjsdb-py/tests/test_evolution.py
@@ -1264,6 +1264,81 @@ class TestParentRelationsConfig:
             assert evolution[0]["entity_id"] == "ds_2"
 
 
+class TestEvolutionExclude:
+    """Tests for evolution_exclude in save()."""
+
+    def test_compare_datasets_exclude_skips_entity(self):
+        """compare_datasets should return no entries for excluded entities."""
+        old_df = pl.DataFrame({"id": [1], "value": ["a"]})
+        new_df = pl.DataFrame({"id": [1, 2], "value": ["b", "c"]})
+
+        excluded = compare_datasets(
+            old_df, new_df, 1234567890, "frequency", exclude={"frequency"}
+        )
+        assert excluded == []
+
+        # A non-excluded entity with the same change still produces entries.
+        kept = compare_datasets(
+            old_df, new_df, 1234567890, "variable", exclude={"frequency"}
+        )
+        assert len(kept) == 2  # one update, one add
+
+    def test_save_excludes_table_from_evolution(self):
+        """Excluded tables emit no add/update/delete entries but export normally.
+
+        A non-excluded table changed in the same save must still be tracked
+        (no over-filtering).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir)
+
+            # Initial data for both tables.
+            db1 = Jsonjsdb()
+            db1._tables["variable"] = Table("variable", db1)
+            db1._tables["frequency"] = Table("frequency", db1)
+            db1["variable"]._df = pl.DataFrame({"id": ["v1"], "name": ["Var 1"]})
+            db1["frequency"]._df = pl.DataFrame(
+                {
+                    "id": ["f1", "f2"],
+                    "variable_id": ["v1", "v1"],
+                    "value": ["a", "b"],
+                    "frequency": [10, 20],
+                }
+            )
+            db1.save(path, track_evolution=False)
+
+            # Change both tables: update in variable, and update/add/delete in
+            # frequency (count change, new modality, disappearing modality).
+            db2 = Jsonjsdb(path)
+            db2["variable"]._df = pl.DataFrame({"id": ["v1"], "name": ["Var 1 bis"]})
+            db2["frequency"]._df = pl.DataFrame(
+                {
+                    "id": ["f1", "f3"],
+                    "variable_id": ["v1", "v1"],
+                    "value": ["a", "c"],
+                    "frequency": [15, 5],  # f1 count changed, f2 gone, f3 new
+                }
+            )
+            db2.save(path, evolution_exclude={"frequency"})
+
+            # Evolution has only the variable update, nothing for frequency.
+            with open(path / "evolution.json") as f:
+                evolution = json.load(f)
+            assert all(e["entity"] != "frequency" for e in evolution)
+            assert [e["entity"] for e in evolution] == ["variable"]
+            assert evolution[0]["type"] == "update"
+            assert evolution[0]["new_value"] == "Var 1 bis"
+
+            # frequency is still exported and up to date.
+            assert (path / "frequency.json").exists()
+            assert (path / "frequency.json.js").exists()
+            with open(path / "frequency.json") as f:
+                freq = json.load(f)
+            freq_ids = {row["id"] for row in freq}
+            assert freq_ids == {"f1", "f3"}
+            assert next(r for r in freq if r["id"] == "f1")["frequency"] == 15
+
+
 class TestCamelCaseFKEdgeCases:
     """Edge case tests for camelCase FK detection."""
 

--- a/jsonjsdb-py/uv.lock
+++ b/jsonjsdb-py/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "jsonjsdb"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "openpyxl" },


### PR DESCRIPTION
## Contexte

Un consommateur (datannurpy) expose une table `frequency` portant les comptages de modalités. À chaque re-scan, une distribution qui bouge génère une ligne d'évolution *par modalité*, ce qui pollue l'évolution de milliers de lignes sans intérêt fonctionnel. Aujourd'hui le seul levier est `track_evolution` (tout-ou-rien) ; les tables `__*` sont skippées mais `frequency` ne peut pas être renommée sans casser l'app.

## Changement

Nouveau kwarg optionnel **`evolution_exclude: set[str] | None = None`** sur `Jsonjsdb.save()`, transmis à `compare_datasets()`. Les tables listées :
- sont **exportées normalement** (json + json.js inchangés) ;
- ne génèrent **aucune** entrée d'évolution (ni `update`, ni `add`, ni `delete`).

Défaut `None` ⇒ comportement strictement identique à aujourd'hui.

### Détails
- `compare_datasets()` : early-return juste après le skip `__` existant.
- Le closure `track_table_evolution` court-circuite **avant** `_get_old_table`, évitant le read disque inutile de l'ancienne table pour les tables exclues (gain sur les grosses tables type `frequency`).
- Version bumpée `0.9.3 → 0.9.4` + CHANGELOG + `uv.lock`.

## Tests

Nouvelle classe `TestEvolutionExclude` :
- unitaire sur `compare_datasets` (exclue = 0 entrée, non-exclue = entrées normales) ;
- end-to-end 2× `save()` : `frequency` subit update + add + delete → aucune ligne d'évolution, mais export à jour ; une table `variable` modifiée en parallèle génère bien son update (pas de sur-filtrage).

Vérifs : 352 passed / 1 xfailed · ruff clean · pyright 0 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)